### PR TITLE
Replace blog references with github references

### DIFF
--- a/whydJS/app/emails/welcome.html
+++ b/whydJS/app/emails/welcome.html
@@ -205,7 +205,7 @@
                                                                     <p style="text-align: center;">
                                                                         <a href="http://twitter.com/open_whyd" style="margin: 0 20px;color: #36bdf0;font-size: 14px;font-weight: bold;text-decoration: none;">Twitter</a>
                                                                         <a href="https://www.facebook.com/openwhyd" style="margin: 0 20px;color: #49629e;font-size: 14px;font-weight: bold;text-decoration: none;">Facebook</a>
-                                                                        <a href="http://blog.openwhyd.org/" style="margin: 0 20px;color: #333538;font-size: 14px;font-weight: bold;text-decoration: none;">Blog</a>
+                                                                        <a href="https://github.com/openwhyd" style="margin: 0 20px;color: #333538;font-size: 14px;font-weight: bold;text-decoration: none;">GitHub</a>
                                                                     </p>
                                                                     <p class="links" style="color: #C0C0C0;text-align: center;">
                                                                         <a href="{{urlPrefix}}/about" style="margin: 0 10px;color: #878787;font-size: 12px;text-decoration: none;">About</a>

--- a/whydJS/app/templates/feed.html
+++ b/whydJS/app/templates/feed.html
@@ -193,11 +193,11 @@
 
 		<div id="sideFooter">
 			<ul>
-				<li><a target="_blank" href="http://blog.openwhyd.org/">Blog</a></li>
+				<li><a target="_blank" href="https://github.com/openwhyd">GitHub</a></li>
 				<li><a target="_blank" href="http://www.facebook.com/openwhyd">Facebook</a></li>
 				<li><a target="_blank" href="http://twitter.com/open_whyd">Twitter</a></li>
 			</ul>
-			<p>OpenWhyd © 2016 Lovingly hand-crafted in Paris</p> <!-- TODO: add link to Github -->
+			<p>OpenWhyd © 2016 Lovingly hand-crafted in Paris</p>
 		</div>
 
 	</div> <!-- END RIGHT BAR-->

--- a/whydJS/app/templates/hotTracks.html
+++ b/whydJS/app/templates/hotTracks.html
@@ -9,11 +9,11 @@
 		</ul>
 		<div id="sideFooter">
 			<ul>
-				<li><a target="_blank" href="http://blog.openwhyd.org/">Blog</a></li>
+				<li><a target="_blank" href="https://github.com/openwhyd">GitHub</a></li>
 				<li><a target="_blank" href="http://www.facebook.com/openwhyd">Facebook</a></li>
 				<li><a target="_blank" href="http://twitter.com/open_whyd">Twitter</a></li>
 			</ul>
-			<p>OpenWhyd © 2016 Lovingly hand-crafted in Paris</p> <!-- TODO: add link to Github -->
+			<p>OpenWhyd © 2016 Lovingly hand-crafted in Paris</p>
 		</div>
 
 	</div>

--- a/whydJS/public/about/index.html
+++ b/whydJS/public/about/index.html
@@ -9,9 +9,9 @@
 	<meta property="fb:admins" content="510739408">
 	<meta property="og:type" content="website">
 	<meta property="og:url" content="http://openwhyd.org/">
-	<meta http-equiv="REFRESH" content="3;url=http://blog.openwhyd.org/about">
+	<meta http-equiv="REFRESH" content="3;url=https://github.com/openwhyd">
 
-  <title>About OpenWhyd - redirecting to blog page...</title>
+  <title>About OpenWhyd - redirecting to GitHub...</title>
 
   <link href="/favicon.ico" rel="shortcut icon" type="image/x-icon">
   <link href="/favicon.png" rel="icon" type="image/png">
@@ -20,10 +20,10 @@
 </head>
 
 <body class="pgRedirect">
-	<p>You are being redirected to <a href="http://blog.openwhyd.org/about">OpenWhyd's blog</a>...</p>
+	<p>You are being redirected to <a href="https://github.com/openwhyd">OpenWhyd's GitHub org</a>...</p>
 	<script>
   setTimeout(function(){
-    window.location.href = "http://blog.openwhyd.org/about";
+    window.location.href = "https://github.com/openwhyd";
   }, 2000);
   </script>
 </body>

--- a/whydJS/public/html/landingOpen.html
+++ b/whydJS/public/html/landingOpen.html
@@ -8,7 +8,7 @@
 		<ul id="genres"></ul>
 		<div id="sideFooter">
 			<ul>
-				<li><a target="_blank" href="http://blog.openwhyd.org/">Blog</a></li>
+				<li><a target="_blank" href="https://github.com/openwhyd">GitHub</a></li>
 				<li><a target="_blank" href="http://www.facebook.com/openwhyd">Facebook</a></li>
 				<li><a target="_blank" href="http://twitter.com/open_whyd">Twitter</a></li>
 			</ul>

--- a/whydJS/public/html/landingPageLaunch.html
+++ b/whydJS/public/html/landingPageLaunch.html
@@ -123,7 +123,7 @@
 	  		<ul>
 	  			<li><a target="_blank" href="http://www.facebook.com/openwhyd">Facebook</a></li>
 	  			<li><a target="_blank" href="http://twitter.com/open_whyd">Twitter</a></li>
-	  			<li class="last-social"><a target="_blank" href="http://blog.openwhyd.org/">Blog</a></li>
+	  			<li class="last-social"><a target="_blank" href="https://github.com/openwhyd">GitHub</a></li>
 	  		</ul>
 	  		<div class="clear"></div>
 	  		<div class="separation"></div>

--- a/whydJS/public/press/index.html
+++ b/whydJS/public/press/index.html
@@ -177,7 +177,7 @@
 					</li>
 					<li class="last">
 						<p>
-							Whyd Blog: <a href="http://blog.openwhyd.org/" alt="Visit the OpenWhyd Blog">http://blog.openwhyd.org/</a>
+							GitHub: <a href="https://github.com/openwhyd" alt="Visit the OpenWhyd GitHub Org">https://github.com/openwhyd</a>
 						</p>
 					</li>
 				</ul>


### PR DESCRIPTION
Replace blog links / mentions with GitHub ones.
- in email templates
- in web templates
- in the "About" redirection page