### PR TITLE
Added twitter card metadata to main template js

### DIFF
--- a/whydJS/app/templates/mainTemplate.js
+++ b/whydJS/app/templates/mainTemplate.js
@@ -52,6 +52,8 @@ function makeMetaHead(options) {
 		'<meta name="google-site-verification" content="mmqzgEU1bjTfJ__nW6zioi7O9vuur1SyYfW44DH6ozg" />',
 		'<meta name="apple-itunes-app" content="app-id=874380201' + (appUrl ? ', app-argument=' + appUrl : '') + '">',
 		'<link rel="image_src" href="' + pageImg + '"/>',
+		'<meta name="twitter:card" content="summary" />',
+		'<meta name="twitter:site" content="@open_whyd" />',
 		'<meta property="og:image" content="' + pageImg + '" />',
 		'<meta property="og:description" content="' + pageDesc + '" />',
 		'<meta property="fb:app_id" content="' + fbId + '" />',


### PR DESCRIPTION
PR for issue #29 . Adds metadata to main html, twitter relies on existing og:* meta tags for rest of info so no need to duplicate there.

Also for the 'site' property I used @open_whyd. They define it as:

> twitter:site
The Twitter @username the card should be attributed to. Required for Twitter Card analytics .

Let me know if that works.