### PR TITLE
fix(security): disable email invites

### DIFF
--- a/app/controllers/invite.js
+++ b/app/controllers/invite.js
@@ -127,6 +127,7 @@ var submitInvites = function(request, reqParams, response) {
   if (!loggedUser || !reqParams) response.badRequest();
   else if (reqParams.email && reqParams.email.join && reqParams.email.length) {
     // === invite by email
+    /*
     var successEmails = [];
     var message =
       reqParams.message && reqParams.message != '' ? reqParams.message : null;
@@ -146,8 +147,14 @@ var submitInvites = function(request, reqParams, response) {
           }
         });
     response.render({ ok: 1, email: successEmails });
+    */
+    response.render({
+      ok: false,
+      error: 'email invites were disabled (#178)'
+    });
   } else if (reqParams.email && typeof reqParams.email == 'string') {
     // === invite by email (1)
+    /*
     users.inviteUserBy(reqParams.email, '' + loggedUser._id, function(invite) {
       if (invite)
         notifEmails.sendInviteBy(
@@ -160,6 +167,11 @@ var submitInvites = function(request, reqParams, response) {
         ok: !!invite,
         email: invite ? invite.email : undefined
       });
+    });
+    */
+    response.render({
+      ok: false,
+      error: 'email invites were disabled (#178)'
     });
   } else if (reqParams.fbId)
     // === invite facebook friend

--- a/app/models/notifEmails.js
+++ b/app/models/notifEmails.js
@@ -77,10 +77,13 @@ exports.sendRegWelcomeAsync = function(storedUser, inviteSender, cb) {
 };
 
 // 4) when a user invites a friends => "your friend invited you to join openwhyd => register"
+// -- disabled (see #178)
+/*
 exports.sendInviteBy = function(senderName, inviteId, email, message) {
   var temp = notifTemplate.generateInviteBy(senderName, inviteId, message);
   emailModel.email(email, temp.subject, temp.bodyText, temp.bodyHtml);
 };
+*/
 
 // 5) when the friend registered => "Your friend just accepted your invitation to whyd"
 exports.sendInviteAccepted = function(senderId, storedUser, cb) {

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -226,6 +226,7 @@
 		</div>
 		{{/playlistContest}}
 
+		<!--
 		<div class="sideBox">
 			<div class="head">
 				<h2>Invite your Friends</h2>
@@ -238,6 +239,7 @@
 				<input type="submit" class="userSubscribe" value="Invite">
 			</form>
 		</div>
+		-->
 
 		<script src="/js/feed-rightbar.js" type="text/javascript" charset="utf-8"></script>
 


### PR DESCRIPTION
Contributes to #178.

The email invite system has been abused between October 10th and 11th, causing our SendGrid account to go over-quota, which caused the email reset procedure emails (see #178) and others to not be sent after that incident.

RIP

![image](https://user-images.githubusercontent.com/531781/47609761-52b51d80-da45-11e8-8e27-7f34376f544f.png)
