### PR TITLE
diagnostic: log invalid value of pId from incrPlayCounter()

### DIFF
--- a/app/controllers/api/post.js
+++ b/app/controllers/api/post.js
@@ -197,9 +197,13 @@ exports.actions = {
   incrPlayCounter: function(p, cb, request) {
     // TODO: prevent a user from sending many calls in a row
     if (!p.uId) return cb && cb({ error: 'not logged in' });
-    // erroneous call made by an old iOS version
-    if (p.pId == '(null)') {
-      console.log('warning: (null) pId');
+    if (mongodb.ObjectId('' + p.pId) === 'invalid_id') {
+      // FYI: an old iOS version was sending a "(null)" value
+      console.log(
+        'warning: skipping invalid pId value in incrPlayCounter:',
+        typeof p.pId,
+        p.pId
+      );
       return cb && cb({ error: 'invalid pId' });
     }
     p.logData = p.logData || {};

--- a/app/controllers/api/post.js
+++ b/app/controllers/api/post.js
@@ -204,6 +204,7 @@ exports.actions = {
         typeof p.pId,
         p.pId
       );
+      console.log('from user agent: ', getShortUserAgent());
       return cb && cb({ error: 'invalid pId' });
     }
     p.logData = p.logData || {};


### PR DESCRIPTION
Contributes to #179.

Will log `warning: skipping invalid pId value in incrPlayCounter` + the value of `pId` whenever it's not a valid ObjectId.