### PR TITLE
fix(email-notif): ability to unsubscribe from notification emails (#186)

### DIFF
--- a/app/controllers/api/unsubscribe.js
+++ b/app/controllers/api/unsubscribe.js
@@ -73,23 +73,28 @@ exports.controller = function(request, reqParams, response) {
 		*/
   }
 
-  if (reqParams && reqParams.uId) {
-    var user = request.getUserFromId(reqParams.uId);
-    if (!user) {
-      console.log({ error: 'user not found' });
-      return render({ error: 'user not found' });
-    }
-    if (reqParams.type && userModel.DEFAULT_PREF[reqParams.type] != undefined) {
-      var prefModif = {};
-      prefModif['pref.' + reqParams.type] = -1;
-      //userModel.setPref(user._id || user.id, prefModif, render);
-      userModel.update(user.id, { $set: prefModif }, render);
-      return;
-    }
+  if (!reqParams || !reqParams.uId) {
+    return render(); // missing uId parameter => let's redirect to /settings
+  }
 
+  var user = request.getUserFromId(reqParams.uId);
+  if (!user) {
+    console.log({ error: 'user not found' });
+    return render({ error: 'user not found' });
+  }
+
+  // if `type` parameter is provided, the user will be unsubscribed from that type of notification
+  if (reqParams.type && userModel.DEFAULT_PREF[reqParams.type] != undefined) {
+    var prefModif = {};
+    prefModif['pref.' + reqParams.type] = -1;
+    //userModel.setPref(user._id || user.id, prefModif, render);
+    userModel.update(user.id, { $set: prefModif }, render);
+  } else {
+    // missing `type` parameter => change settings for all notifications emails
     var newFreq = -1; // "never send notification emails", by default (real "unsubscribe")
-    if (reqParams.action && reqParams.action == 'reduce')
+    if (reqParams.action && reqParams.action == 'reduce') {
       newFreq = getNextFreq(userModel.getEmailNotifsFreq(user));
+    }
     setNotifFreq(user, newFreq, render);
-  } else render();
+  }
 };

--- a/app/controllers/api/unsubscribe.js
+++ b/app/controllers/api/unsubscribe.js
@@ -42,6 +42,10 @@ function setNotifFreq(user, freq, cb) {
   userModel.setPref(user._id || user.id, pref, cb);
 }
 
+function withLink(html) {
+  return '<p>' + html + "</p><p><a href='/settings'>Edit your settings</a></p>";
+}
+
 exports.controller = function(request, reqParams, response) {
   request.logToConsole('unsubscribe.controller', reqParams);
 
@@ -51,17 +55,24 @@ exports.controller = function(request, reqParams, response) {
       return;
     }
     if (r.pwd) delete r.pwd;
+    console.error('UNSUB RENDER', r);
     // updated email notif frequency
-    if (r.pref) {
+    if (r.pref && reqParams.action == 'reduce') {
       var newFreqlabel =
         userModel.EM_FREQ_LABEL['' + userModel.getEmailNotifsFreq(r)];
       var html =
         'Starting now, the frequency of email notifications you will receive is set to: ' +
         newFreqlabel;
-      html =
-        '<p>' + html + "</p><p><a href='/settings'>Edit your settings</a></p>";
-      response.render(html, null, { 'content-type': 'text/html' });
-    } else response.render(r);
+      response.render(withLink(html), null, { 'content-type': 'text/html' });
+    } else if (r.pref) {
+      // user unsubscribed
+      var type = userModel.EM_LABEL[reqParams.type] || 'all';
+      var html =
+        'You successfully unsubscribed from email notifications: ' + type;
+      response.render(withLink(html), null, { 'content-type': 'text/html' });
+    } else {
+      response.render(r);
+    }
     /*
 		if (r && r.html)
 			response.render(r.html, null, {'content-type': 'text/html'});

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -98,6 +98,18 @@ exports.EM_FREQ_LABEL = {
   '7': 'weekly'
 };
 
+exports.EM_LABEL = {
+  emLik: 'likes',
+  emAdd: 're-posts',
+  emSub: 'subscriptions',
+  emSam: 'same tracks',
+  emCom: 'comments',
+  emMen: 'mentions',
+  emRep: 'replies',
+  emFrd: 'friends',
+  emAcc: 'accepted invites'
+};
+
 var TESTING_DIGEST = config.digestImmediate;
 
 (function parseHandlesFromRouteFile(routeFile) {

--- a/test/acceptance-cmds.js
+++ b/test/acceptance-cmds.js
@@ -68,6 +68,13 @@ browser.addCommand('clickOnContent', function(text) {
     .click();
 });
 
+browser.addCommand('clickOnVisibleSelector', function(selector) {
+  $$(selector)
+    .filter(node => node.isVisible())[0]
+    .click();
+  return browser;
+});
+
 // other helpers
 /*
 exports.takeSnapshot = function takeSnapshot() {

--- a/test/specs/email-notifications.tests.js
+++ b/test/specs/email-notifications.tests.js
@@ -1,0 +1,44 @@
+var assert = require('assert');
+var { URL_PREFIX, ADMIN_USER: user } = require('../fixtures.js');
+const webUI = require('../web-ui.js');
+
+const request = require('request');
+
+require('../acceptance-cmds.js'); // also checks that openwhyd's server is tested against the test database
+// TODO: make sure that DB was reset before starting Openwhyd's app server
+// ... AND that the user cache was reset as well. (e.g. by restarting Openwhyd's server)
+
+describe('email notifications', function() {
+  let user;
+
+  it('create a test user', function() {
+    const username = 'test-email-notif-user-' + new Date().getTime();
+    user = webUI.signup({
+      username,
+      email: `${username}@openwhyd.org`,
+      password: `dummy`
+    });
+  });
+
+  it(`user has instant email notifications"`, function() {
+    assert.equal(user.pref.emSub, 0);
+  });
+
+  it(`activate daily email notifications`, function() {
+    browser.url(`${URL_PREFIX}/settings`).waitForContent(/Notifications/);
+    browser.clickOnContent('Notifications');
+    browser.waitForContent(/Daily/);
+    browser.clickOnContent('Daily');
+    browser.clickOnVisibleSelector('input[type="submit"]');
+  });
+
+  it(`user now has daily email notifications"`, function() {
+    browser.url(`${URL_PREFIX}/api/user`);
+    const { pref } = JSON.parse(browser.getText('pre'));
+    assert.equal(pref.emSub, 1);
+  });
+
+  //webUI.logout();
+});
+
+// Webdriver API documentation: http://webdriver.io/api.html

--- a/test/specs/email-notifications.tests.js
+++ b/test/specs/email-notifications.tests.js
@@ -1,14 +1,16 @@
 var assert = require('assert');
-var { URL_PREFIX, ADMIN_USER: user } = require('../fixtures.js');
+var { URL_PREFIX, ADMIN_USER } = require('../fixtures.js');
 const webUI = require('../web-ui.js');
 
 const request = require('request');
+
+const URL_UNSUB = `${URL_PREFIX}/api/unsubscribe`;
 
 require('../acceptance-cmds.js'); // also checks that openwhyd's server is tested against the test database
 // TODO: make sure that DB was reset before starting Openwhyd's app server
 // ... AND that the user cache was reset as well. (e.g. by restarting Openwhyd's server)
 
-describe('email notifications', function() {
+describe('reduce frequency of email notifications', function() {
   let user;
 
   it('create a test user', function() {
@@ -24,7 +26,7 @@ describe('email notifications', function() {
     assert.equal(user.pref.emSub, 0);
   });
 
-  it(`activate daily email notifications`, function() {
+  it(`user activates daily email notifications`, function() {
     browser.url(`${URL_PREFIX}/settings`).waitForContent(/Notifications/);
     browser.clickOnContent('Notifications');
     browser.waitForContent(/Daily/);
@@ -38,7 +40,75 @@ describe('email notifications', function() {
     assert.equal(pref.emSub, 1);
   });
 
-  //webUI.logout();
+  /*
+    it(`other user becomes a subscriber"`, function() {
+      webUI.logout();
+      webUI.loginAs(ADMIN_USER);
+      browser.url(`${URL_PREFIX}/u/${user.id}`);
+      browser.waitForContent(/Subscribe/);
+      browser.clickOnContent('Subscribe');
+    });
+    */
+
+  it(`user reduces frequency of notifications from email`, function() {
+    browser.url(`${URL_UNSUB}?uId=${user.id}&type=emSub&action=reduce`);
+    // URL is generated in app/templates/notifDigest.js
+  });
+
+  it(`user sees switch to weekly notifications emails`, function() {
+    const response = browser.getText('body');
+    console.log({ response });
+    assert(/weekly/.test(response), 'response should contain "weekly"');
+  });
+
+  it(`user now has weekly email notifications"`, function() {
+    browser.url(`${URL_PREFIX}/api/user`);
+    const { pref } = JSON.parse(browser.getText('pre'));
+    assert.equal(pref.emSub, 7);
+  });
+
+  it(`user logs out`, function() {
+    webUI.clearSession();
+  });
+});
+
+describe(`unsubscribe from email notifications`, function() {
+  let user;
+
+  it('create a test user', function() {
+    const username = 'test-email-notif-user-' + new Date().getTime();
+    user = webUI.signup({
+      username,
+      email: `${username}@openwhyd.org`,
+      password: `dummy`
+    });
+  });
+
+  it(`user has instant email notifications"`, function() {
+    assert.equal(user.pref.emSub, 0);
+  });
+
+  it(`user unsubscribes from email`, function() {
+    browser.url(`${URL_UNSUB}?uId=${user.id}&type=emSub`);
+    // URL is generated in app/templates/notifDigest.js
+  });
+
+  it(`user sees unsubscription message`, function() {
+    const response = browser.getText('body');
+    console.log({ response });
+    assert(/never/.test(response), 'response should contain "never"');
+    // messages are defined in app/controllers/api/unsubscribe.js
+  });
+
+  it(`user was effectively unsubscribed from email notifications"`, function() {
+    browser.url(`${URL_PREFIX}/api/user`);
+    const { pref } = JSON.parse(browser.getText('pre'));
+    assert.equal(pref.emSub, -1);
+  });
+
+  it(`user logs out`, function() {
+    webUI.clearSession();
+  });
 });
 
 // Webdriver API documentation: http://webdriver.io/api.html

--- a/test/specs/email-notifications.tests.js
+++ b/test/specs/email-notifications.tests.js
@@ -57,7 +57,7 @@ describe('reduce frequency of email notifications', function() {
 
   it(`user sees switch to weekly notifications emails`, function() {
     const response = browser.getText('body');
-    console.log({ response });
+    // console.log({ response });
     assert(/weekly/.test(response), 'response should contain "weekly"');
   });
 
@@ -95,7 +95,7 @@ describe(`unsubscribe from email notifications`, function() {
 
   it(`user sees unsubscription message`, function() {
     const response = browser.getText('body');
-    console.log({ response });
+    // console.log({ response });
     assert(
       /unsubscribed/.test(response),
       'response should contain "unsubscribed"'

--- a/test/specs/email-notifications.tests.js
+++ b/test/specs/email-notifications.tests.js
@@ -96,7 +96,10 @@ describe(`unsubscribe from email notifications`, function() {
   it(`user sees unsubscription message`, function() {
     const response = browser.getText('body');
     console.log({ response });
-    assert(/never/.test(response), 'response should contain "never"');
+    assert(
+      /unsubscribed/.test(response),
+      'response should contain "unsubscribed"'
+    );
     // messages are defined in app/controllers/api/unsubscribe.js
   });
 

--- a/test/web-ui.js
+++ b/test/web-ui.js
@@ -59,3 +59,5 @@ exports.logout = function(user) {
     );
   });
 };
+
+exports.clearSession = () => browser.url(`${URL_PREFIX}/login?action=logout`);

--- a/test/web-ui.js
+++ b/test/web-ui.js
@@ -1,6 +1,34 @@
 var assert = require('assert');
 var { URL_PREFIX } = require('./fixtures.js');
 
+exports.signup = function({ email, password, username }) {
+  const WAIT_DURATION = 5000;
+  console.log('[signup] create user', { email });
+  browser
+    .url(URL_PREFIX)
+    .click('#signup')
+    .waitForVisible('input[name="email"]');
+  browser
+    .setValue('input[name="name"]', username)
+    .setValue('input[name="email"]', email)
+    .setValue('input[name="password"]', password)
+    .click('input[type="submit"]');
+  console.log('[signup] consent');
+  browser
+    .url(`${URL_PREFIX}/consent`)
+    .scroll('input[type="checkbox"]')
+    .click('input[type="checkbox"]')
+    .click('input[type="submit"]')
+    .waitUntil(
+      () => !/consent/.test(browser.getUrl()),
+      WAIT_DURATION,
+      'expected to be on / after 5s'
+    );
+  console.log('[signup] fetch user data');
+  browser.url(`${URL_PREFIX}/api/user`);
+  return JSON.parse(browser.getText('pre'));
+};
+
 exports.loginAs = function(user) {
   return function() {
     browser


### PR DESCRIPTION
Closes #186.

- fixes reduction of frequency for email notifications
- fixes message after unsubscribing from notification emails
- refactors unsubscribe logic, for better clarity
- adds tests for email notifications
- adds `browser.clickOnVisibleSelector()` wdio command
- adds `webUI.signup()` for tests
