### PR TITLE
fix: append PORT to URL_PREFIX only if WHYD_URL_PREFIX is not provided

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,8 +89,8 @@ var params = (process.appParams = {
   dev: process.env['WHYD_DEV'] || false, // hot re-loading of node controllers, models and views
   port: process.env['WHYD_PORT'] || 8080, // overrides app.conf
   urlPrefix:
-    (process.env['WHYD_URL_PREFIX'] || 'http://localhost:') +
-    (process.env['WHYD_PORT'] || 8080), // base URL of the app
+    process.env['WHYD_URL_PREFIX'] ||
+    `http://localhost:${process.env['WHYD_PORT'] || 8080}`, // base URL of the app
   mongoDbHost: process.env['MONGODB_HOST'] || 'localhost',
   mongoDbPort: process.env['MONGODB_PORT'] || mongodb.Connection.DEFAULT_PORT, // 27017
   mongoDbAuthUser: process.env['MONGODB_USER'],


### PR DESCRIPTION
What does this PR do / solve?
-----------------------------

Bug: a user reported that the "unsubscribe" link from his digest/notification email did not work:

![image](https://user-images.githubusercontent.com/531781/59157291-798e0480-8aa8-11e9-8131-61888239b059.png)

Source: https://github.com/openwhyd/openwhyd/commit/cc3af51b2d24e98d24e10583add56ab83bd535de#commitcomment-33865126


Overview of changes
-------------------

This PR fixes the way the URL_PREFIX is computed when running in production. It should fix the URL of unsubscribe links.
