### PR TITLE
fix(sessions): make user cookie persistant

### DIFF
--- a/app.js
+++ b/app.js
@@ -153,7 +153,7 @@ function start() {
       url: makeMongoUrl(params)
     }),
     name: 'whydSid',
-    ttl: 60 * 60 * 24 * 365, // 1 year
+    maxAge: 365 * 24 * 60 * 60 * 1000, // cookies expire in 1 year (provided in milliseconds)
     resave: false, // required, cf https://www.npmjs.com/package/express-session#resave
     saveUninitialized: false // required, cf https://www.npmjs.com/package/express-session#saveuninitialized
   });

--- a/app.js
+++ b/app.js
@@ -144,16 +144,16 @@ function makeMongoUrl(params) {
 }
 
 function start() {
-  var myHttp = require('./app/lib/my-http-wrapper/http');
+  const myHttp = require('./app/lib/my-http-wrapper/http');
   const session = require('express-session');
   const MongoStore = require('connect-mongo')(session);
   const sessionMiddleware = session({
     secret: process.env.WHYD_SESSION_SECRET.substr(),
     store: new MongoStore({
-      url: makeMongoUrl(params),
-      ttl: 60 * 60 * 24 * 365 // 1 year
+      url: makeMongoUrl(params)
     }),
     name: 'whydSid',
+    ttl: 60 * 60 * 24 * 365, // 1 year
     resave: false, // required, cf https://www.npmjs.com/package/express-session#resave
     saveUninitialized: false // required, cf https://www.npmjs.com/package/express-session#saveuninitialized
   });


### PR DESCRIPTION
Closes #208.

What does this PR do / solve?
-----------------------------

User needs to login again, everytime they restarts their browser. (including Openwhyd's iOS and Electron apps)

Overview of changes
-------------------

Specify a `maxAge` for cookies, so that they don't become browser-session-based by default.

How to test this PR?
--------------------

1. open an openwhyd session by logging in
2. shut down your web browser, then restart it
3. you should still be connected to your openwhyd account
