### PR TITLE
fix(sessions): define maxAge in the cookie property

### DIFF
--- a/app.js
+++ b/app.js
@@ -152,8 +152,10 @@ function start() {
     store: new MongoStore({
       url: makeMongoUrl(params)
     }),
+    cookie: {
+      maxAge: 365 * 24 * 60 * 60 * 1000 // cookies expire in 1 year (provided in milliseconds)
+    },
     name: 'whydSid',
-    maxAge: 365 * 24 * 60 * 60 * 1000, // cookies expire in 1 year (provided in milliseconds)
     resave: false, // required, cf https://www.npmjs.com/package/express-session#resave
     saveUninitialized: false // required, cf https://www.npmjs.com/package/express-session#saveuninitialized
   });


### PR DESCRIPTION
Closes #208.

What does this PR do / solve?
-----------------------------

In #209, I re-introduced cookie expiration using `express-session`'s `maxAge` property, but had defined it at the wrong path of the settings object.

Overview of changes
-------------------

Now defined in `cookie.maxAge` instead of just `maxAge`.

How to test this PR?
--------------------

See #209.