### PR TITLE
fix: typo on gdpr consent screen

### DIFF
--- a/config/gdpr-consent-en.md
+++ b/config/gdpr-consent-en.md
@@ -1,4 +1,4 @@
-**Before using Openwhyd, and in compliance with [RGPD](https://www.eugdpr.org/), please read the conditions below and give your consent if you are comfortable with them.**
+**Before using Openwhyd, and in compliance with [GDPR](https://www.eugdpr.org/), please read the conditions below and give your consent if you are comfortable with them.**
 
 ## Project
 


### PR DESCRIPTION
This PR replaces "RGPD" by "GDPR", on the English version of the GDPR consent page:

![image](https://user-images.githubusercontent.com/531781/63964789-2371a180-ca98-11e9-920a-71414afe5db9.png)
