### PR TITLE
create a mongodb job based on docker image

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,9 +15,17 @@ jobs:
     - name: start db
       uses: docker://mongo:3.4
   build:
-    runs-on: ubuntu-latest
+   runs-on: ubuntu-latest
+   strategy:
+     matrix:
+       node-version: [8.x]
     # needs: mongodb
     steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
     - name: npm install, build, and test
       run: |
         npm install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,10 +15,10 @@ jobs:
     - name: start db
       uses: docker://mongo:3.4
   build:
-   runs-on: ubuntu-latest
-   strategy:
-     matrix:
-       node-version: [8.x]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [8.x]
     # needs: mongodb
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,13 +9,13 @@ on:
     - master
 
 jobs:
-  mongodb:
-    runs-on: ubuntu-latest
-    steps:
-    - name: start db
-      uses: docker://mongo:3.4
   build:
     runs-on: ubuntu-latest
+    services:
+      mongodb:
+        image: docker://mongo:3.4
+        ports:
+        - 27117:27017
     strategy:
       matrix:
         node-version: [8.x]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
       mongodb:
         image: docker://mongo:3.4
         ports:
-        - 27117:27017
+        - 27017:27017
     strategy:
       matrix:
         node-version: [8.x]

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,20 +9,15 @@ on:
     - master
 
 jobs:
-  build:
-
+  mongodb:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [8.x]
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+    - name: start db
+      uses: docker://mongo:3.4
+  build:
+    runs-on: ubuntu-latest
+    needs: mongodb
+    steps:
     - name: npm install, build, and test
       run: |
         npm install

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       uses: docker://mongo:3.4
   build:
     runs-on: ubuntu-latest
-    needs: mongodb
+    # needs: mongodb
     steps:
     - name: npm install, build, and test
       run: |


### PR DESCRIPTION
Use GitHub Actions to run automated tests whenever a pull request targets `master`, or a commit is merged to `master`.

Alternative if our current and previous CI systems: CircleCI and TravisCI.

This reference helped a lot: [Workflow syntax for GitHub Actions - GitHub Help](https://help.github.com/en/articles/workflow-syntax-for-github-actions)

Related: #205.

Next step, if it works well:
- [ ] add `semantic-release` to this workflow
- [ ] add coverage to this workflow
- [ ] disable CircleCI
