### PR TITLE
fix(eslint): support ES6 and ES2017 syntax

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
-    "extends": [
-        "plugin:prettier/recommended"
-    ],
-    "plugins": []
+  "extends": ["plugin:prettier/recommended"],
+  "plugins": [],
+  "parserOptions": {
+    "ecmaVersion": 2017
+  },
+  "env": {
+    "es6": true
+  }
 }


### PR DESCRIPTION
To prevent ESLint errors on keywords like `const` and `await`.