### PR TITLE
fix(mongodb): prevent "db.collections is not a function" error

### DIFF
--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -144,12 +144,14 @@ exports.init = function(readyCallback) {
   var authStr = '';
   if (authUser && authPassword) authStr = authUser + ':' + authPassword + '@';
 
-  var url = 'mongodb://' + authStr + host + ':' + port + '/' + dbName; // + "?w=1";
+  var url = 'mongodb://' + authStr + host + ':' + port; // + "?w=1";
 
-  console.log('Connecting to ' + url + '...');
+  console.log('Connecting to ' + url + '/' + dbName + '...');
 
   var options = {
     native_parser: true,
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
     //strict: false,
     //safe: false,
     w: 'majority' // write concern: (value of > -1 or the string 'majority'), where < 1 means no write acknowlegement
@@ -158,8 +160,10 @@ exports.init = function(readyCallback) {
   //var dbserver = new mongodb.Server(host, port, {auto_reconnect:true});
   //var db = new mongodb.Db(dbName, dbserver, options);
 
-  mongodb.MongoClient.connect(url, options, function(err, db) {
+  mongodb.MongoClient.connect(url, options, function(err, client) {
     if (err) throw err;
+
+    const db = client.db(dbName);
 
     db.addListener('error', function(e) {
       console.log('MongoDB model async error: ', e);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,6 +1886,11 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
+    },
     "bufferjs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-1.1.0.tgz",
@@ -6092,13 +6097,73 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
-      "integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
+      "version": "2.2.36",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
+      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
       "requires": {
-        "bson": "^1.1.1",
-        "require_optional": "^1.0.1",
-        "safe-buffer": "^5.1.2"
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.20",
+        "readable-stream": "2.2.7"
+      },
+      "dependencies": {
+        "es6-promise": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+        },
+        "readable-stream": {
+          "version": "2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "mongodb-core": {
+      "version": "2.1.20",
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
+      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
+      "requires": {
+        "bson": "~1.0.4",
+        "require_optional": "~1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
+        }
       }
     },
     "ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1886,11 +1886,6 @@
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
       "dev": true
     },
-    "buffer-shims": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-    },
     "bufferjs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/bufferjs/-/bufferjs-1.1.0.tgz",
@@ -6097,73 +6092,13 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
-      "version": "2.2.36",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.36.tgz",
-      "integrity": "sha512-P2SBLQ8Z0PVx71ngoXwo12+FiSfbNfGOClAao03/bant5DgLNkOPAck5IaJcEk4gKlQhDEURzfR3xuBG1/B+IA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.3.2.tgz",
+      "integrity": "sha512-fqJt3iywelk4yKu/lfwQg163Bjpo5zDKhXiohycvon4iQHbrfflSAz9AIlRE6496Pm/dQKQK5bMigdVo2s6gBg==",
       "requires": {
-        "es6-promise": "3.2.1",
-        "mongodb-core": "2.1.20",
-        "readable-stream": "2.2.7"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
-          "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
-        },
-        "readable-stream": {
-          "version": "2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
-          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
-          "requires": {
-            "buffer-shims": "~1.0.0",
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~1.0.0",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "mongodb-core": {
-      "version": "2.1.20",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.20.tgz",
-      "integrity": "sha512-IN57CX5/Q1bhDq6ShAR6gIv4koFsZP7L8WOK1S0lR0pVDQaScffSMV5jxubLsmZ7J+UdqmykKw4r9hG3XQEGgQ==",
-      "requires": {
-        "bson": "~1.0.4",
-        "require_optional": "~1.0.0"
-      },
-      "dependencies": {
-        "bson": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
-          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
-        }
+        "bson": "^1.1.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2"
       }
     },
     "ms": {
@@ -10368,13 +10303,8 @@
       "resolved": "https://registry.npmjs.org/playemjs/-/playemjs-0.3.0.tgz",
       "integrity": "sha512-QsEmOf5xCRn0+3rEL4SMutBrsHKRbR7Vn1OLgWeXXGgZTlagtyYevSFrgOCMQrCdh34irGOY37ZFwmm9uaSNLw==",
       "requires": {
+        "soundmanager2": "github:scottschiller/SoundManager2",
         "swfobject": "^2.2.1"
-      },
-      "dependencies": {
-        "soundmanager2": {
-          "version": "github:scottschiller/SoundManager2#f432aa9ed96a0f9022e72fc4a1b977ba0643ed71",
-          "from": "github:scottschiller/SoundManager2#f432aa9ed96a0f9022e72fc4a1b977ba0643ed71"
-        }
       }
     },
     "posix-character-classes": {
@@ -11787,6 +11717,10 @@
       "requires": {
         "kind-of": "^3.2.0"
       }
+    },
+    "soundmanager2": {
+      "version": "github:scottschiller/SoundManager2#f432aa9ed96a0f9022e72fc4a1b977ba0643ed71",
+      "from": "github:scottschiller/SoundManager2"
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "hogan.js": "2.0.0",
     "htmlparser": "*",
     "iconv": ">=2.0.6",
-    "mongodb": "^2.2.29",
+    "mongodb": "^3.3.2",
     "object-sizeof": "^1.3.0",
     "playemjs": "0.3.0",
     "q-set": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "hogan.js": "2.0.0",
     "htmlparser": "*",
     "iconv": ">=2.0.6",
-    "mongodb": "^3.3.2",
+    "mongodb": "^2.2.33",
     "object-sizeof": "^1.3.0",
     "playemjs": "0.3.0",
     "q-set": "^2.0.8",

--- a/scripts/algolia-search-index/mongodb-wrapper.js
+++ b/scripts/algolia-search-index/mongodb-wrapper.js
@@ -3,20 +3,21 @@ const Progress = require('./Progress');
 
 var MONGO_OPTIONS = {
   native_parser: true,
+  useNewUrlParser: true,
+  useUnifiedTopology: true,
   //strict: false,
   //safe: false,
   w: 'majority' // write concern: (value of > -1 or the string 'majority'), where < 1 means no write acknowlegement
 };
 
 const makeConnUrl = params => {
-  var dbName = params.mongoDbDatabase || process.env.MONGODB_DATABASE;
   var host = params.mongoDbHost || process.env.MONGODB_HOST;
   var port = params.mongoDbPort || process.env.MONGODB_PORT;
   var authUser = params.mongoDbAuthUser || process.env.MONGODB_USER;
   var authPassword = params.mongoDbAuthPassword || process.env.MONGODB_PASS;
   var authStr =
     authUser && authPassword ? authUser + ':' + authPassword + '@' : '';
-  return 'mongodb://' + authStr + host + ':' + port + '/' + dbName;
+  return 'mongodb://' + authStr + host + ':' + port;
 };
 
 // populates db.<collection_name>, for each collection
@@ -41,14 +42,15 @@ const cacheCollections = function(db, callback) {
 
 const initMongo = (params, callback) => {
   var url = makeConnUrl(params);
-  console.log('Connecting to ' + url + '...');
-  mongodb.MongoClient.connect(url, MONGO_OPTIONS, (err, db) => {
+  var dbName = params.mongoDbDatabase || process.env.MONGODB_DATABASE;
+  console.log('Connecting to ' + url + '/' + dbName + '...');
+  mongodb.MongoClient.connect(url, MONGO_OPTIONS, (err, client) => {
     if (err) {
       callback(err);
     } else {
+      const db = client.db(dbName);
       db.addListener('error', function(err) {
         console.log('MongoDB model async error: ', err);
-        throw err;
       });
       cacheCollections(db, callback); // will mutate db and callback
     }


### PR DESCRIPTION
What does this PR do / solve?
-----------------------------

Initial goal was to fix the following warning: `DeprecationWarning: current Server Discovery and Monitoring engine is deprecated, and will be removed in a future version. To use the new Server Discover and Monitoring engine, pass option { useUnifiedTopology: true } to MongoClient.connect`

As a first step, this PR fixes the `db.collections is not a function` error, when trying to run `docker-compose up --build`.

Overview of changes
-------------------

- upgrade the `mongodb` client to a more recent version: `2.2.33`
- switch to the new Mongo URI format

How to test this PR?
--------------------

```
$ docker-compose up --build -d
$ npm run test-docker
```