### PR TITLE
refact(template): change load more div to a tag

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,4 @@
 {
-  "editor.formatOnSave": true,
+  "editor.formatOnSave": false,
   "eslint.autoFixOnSave": true
 }

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -517,7 +517,7 @@
 				{{/ownProfile}}
 				{{/emptyFeed}}
 				{{#hasMore}}
-				<div class="btnLoadMore" onclick="loadMore()"><div>&nbsp;</div><span>Load more</span></div>
+				<div class="btnLoadMore" onclick="loadMore()"><div>&nbsp;</div><a>Load more</a></div>
 				{{/hasMore}}
 
 				<script>

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -517,7 +517,7 @@
 				{{/ownProfile}}
 				{{/emptyFeed}}
 				{{#hasMore}}
-				<div class="btnLoadMore" onclick="loadMore()"><div>&nbsp;</div><a>Load more</a></div>
+				<div class="btnLoadMore" onclick="loadMore()"><div>&nbsp;</div><a href="?after={{lastPid}}">Load more</a></div>
 				{{/hasMore}}
 
 				<script>


### PR DESCRIPTION
Change Load more div on feed (/all) template to an a tag
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #221 

What does this PR do / solve?
Changes Load more text to a hyperlink to be able to open next page results in another tab or window
Allows for crawlers to find the URL of that next page
-----------------------------
Overview of changes
-------------------
![load_more](https://user-images.githubusercontent.com/23284377/66944218-5e14a680-f012-11e9-91d2-7ba252f6d097.png)

How to test this PR?
--------------------

Run the solution with "docker-compose up"
Head to stream page and scroll to the bottom where the "Load more" button is located
Make sure text is a clickable link
For now, ensure clicking the link loads more results on the page
