### PR TITLE
fix(privacy): don't log email addresses and password hashes

### DIFF
--- a/app/controllers/api/login.js
+++ b/app/controllers/api/login.js
@@ -89,7 +89,6 @@ exports.handleRequest = function(request, form, response, ignorePassword) {
       }
     });
   } else if (form.email) {
-    console.log('email=', form.email);
     form.email = emailModel.normalize(form.email);
 
     userModel[form.email.indexOf('@') > -1 ? 'fetchByEmail' : 'fetchByHandle'](

--- a/app/controllers/api/login.js
+++ b/app/controllers/api/login.js
@@ -1,7 +1,5 @@
 /**
- * login controller
- * authentify users, with IE support
- * @author adrienjoly, whyd
+ * login controller, to authenticate users
  */
 var config = require('../../models/config.js');
 var emailModel = require('../../models/email.js');
@@ -118,11 +116,11 @@ exports.handleRequest = function(request, form, response, ignorePassword) {
             userModel.update(dbUser._id, {
               $set: {
                 fbId: form.fbUid,
-                fbTok: form.fbTok // accesstoken provided on last facebook login
+                fbTok: form.fbTok // access token provided on last facebook login
               }
             });
           renderRedirect(form.redirect || '/', dbUser);
-          return; // prevent default reponse (renderForm)
+          return; // prevent default response (renderForm)
         } else if (form.action != 'logout') {
           form.wrongPassword = 1;
           form.error = 'Your password seems wrong... Try again!';

--- a/app/models/emailSendgrid.js
+++ b/app/models/emailSendgrid.js
@@ -5,6 +5,7 @@
  **/
 
 var https = require('https');
+var snip = require('./../snip.js');
 //var email = require("emailjs/email");
 
 var querystring = require('querystring');
@@ -30,7 +31,7 @@ exports.email = function(
   userName,
   callback
 ) {
-  console.log('email', emailAddr, subject);
+  console.log('email', snip.formatEmail(emailAddr), subject);
   /*
 	var message = email.message.create({
 		text: textContent, 

--- a/app/models/logging.js
+++ b/app/models/logging.js
@@ -1,6 +1,7 @@
 var http = require('http');
 var querystring = require('querystring');
 var errorTemplate = require('../templates/error.js');
+const snip = require('../snip.js');
 
 const genReqLogLine = ({ head, method, path, params, suffix }) =>
   !process.appParams.color
@@ -26,7 +27,10 @@ http.IncomingMessage.prototype.logToConsole = function(suffix, params) {
       head: '=== ' + new Date().toUTCString(),
       method: this.method,
       path: this.url.split('?'),
-      params: params ? JSON.stringify(params) : '',
+      params:
+        typeof params === 'object'
+          ? JSON.stringify(snip.formatPrivateFields(params))
+          : '',
       suffix: suffix ? '(' + suffix + ')' : ''
     })
   );

--- a/app/models/logging.js
+++ b/app/models/logging.js
@@ -2,31 +2,35 @@ var http = require('http');
 var querystring = require('querystring');
 var errorTemplate = require('../templates/error.js');
 
-http.IncomingMessage.prototype.logToConsole = function(suffix, params) {
-  var head = '=== ' + new Date().toUTCString(),
-    path = this.url.split('?'); /*[0]*/
-  params = params ? JSON.stringify(params) : '';
-  suffix = suffix ? '(' + suffix + ')' : '';
-  // output with colors
-  console.log(
-    head.grey,
-    this.method.cyan,
-    path[0].green +
-      (path.length > 1 ? '?' + path.slice(1).join('?') : '').yellow,
-    suffix.white,
-    params.grey
-  ); // -> stdout
-};
+const genReqLogLine = ({ head, method, path, params, suffix }) =>
+  !process.appParams.color
+    ? [
+        head,
+        method,
+        path[0] + (path.length > 1 ? '?' + path.slice(1).join('?') : ''),
+        suffix,
+        params
+      ]
+    : [
+        head.grey,
+        method.cyan,
+        path[0].green +
+          (path.length > 1 ? '?' + path.slice(1).join('?') : '').yellow,
+        suffix.white,
+        params.grey
+      ];
 
-if (!process.appParams.color)
-  http.IncomingMessage.prototype.logToConsole = function(suffix, params) {
-    var head = '=== ' + new Date().toUTCString(),
-      path = this.url; /*.split("?")[0]*/
-    params = params ? JSON.stringify(params) : '';
-    suffix = suffix ? '(' + suffix + ')' : '';
-    // output without colors
-    console.log(head, this.method, path, suffix, params);
-  };
+http.IncomingMessage.prototype.logToConsole = function(suffix, params) {
+  console.log(
+    ...genReqLogLine({
+      head: '=== ' + new Date().toUTCString(),
+      method: this.method,
+      path: this.url.split('?'),
+      params: params ? JSON.stringify(params) : '',
+      suffix: suffix ? '(' + suffix + ')' : ''
+    })
+  );
+};
 
 var config = require('./config.js');
 var mongodb = require('./mongodb.js');

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -235,7 +235,7 @@ function processUsers(list) {
 }
 
 function fetch(q, handler) {
-  console.log('fetching user ', q, '...');
+  snip.console.log('fetching user ', q, '...');
   if (q._id && typeof q._id == 'string') q._id = ObjectId(q._id);
   mongodb.collections['user'].findOne(q, function(err, user) {
     if (user) {

--- a/app/snip.js
+++ b/app/snip.js
@@ -9,6 +9,31 @@ var querystring = require('querystring');
 
 var firstWeek = new Date('Monday January 3, 2011 08:00'); // week #1 = 1st of january 2010
 
+// privacy helper: anonymise email address
+exports.formatEmail = function(emailAddr) {
+  if (typeof emailAddr !== 'string' || emailAddr.length < 1)
+    return '<invalid_email>';
+  const [name, domain] = emailAddr.split('@');
+  return name
+    .substring(0, 1)
+    .concat('*********@')
+    .concat(domain);
+};
+
+// privacy-enforcing console.log helper
+exports.console = {
+  log(...args) {
+    const filteredArgs = args.map(arg => {
+      if (typeof arg === 'object' && typeof arg.email === 'string') {
+        return { ...arg, email: exports.formatEmail(arg.email) };
+      } else {
+        return arg;
+      }
+    });
+    console.log(...filteredArgs);
+  }
+};
+
 exports.getWeekNumber = function(date) {
   return date && Math.floor(1 + (date - firstWeek) / 1000 / 60 / 60 / 24 / 7);
 };

--- a/app/snip.js
+++ b/app/snip.js
@@ -20,16 +20,18 @@ exports.formatEmail = function(emailAddr) {
     .concat(domain);
 };
 
+exports.formatPrivateFields = obj => {
+  if (typeof obj !== 'object') return obj;
+  const res = { ...obj };
+  if (typeof obj.email === 'string') res.email = exports.formatEmail(obj.email);
+  if (typeof obj.md5 === 'string') res.md5 = '<MD5_HASH>';
+  return res;
+};
+
 // privacy-enforcing console.log helper
 exports.console = {
   log(...args) {
-    const filteredArgs = args.map(arg => {
-      if (typeof arg === 'object' && typeof arg.email === 'string') {
-        return { ...arg, email: exports.formatEmail(arg.email) };
-      } else {
-        return arg;
-      }
-    });
+    const filteredArgs = args.map(exports.formatPrivateFields);
     console.log(...filteredArgs);
   }
 };

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -7,13 +7,13 @@ Docker makes it easy and safe to install and start the two servers required for 
 1. Install [Docker Client](https://www.docker.com/community-edition) and start it
 2. [Install Git](https://www.atlassian.com/git/tutorials/install-git) if you don't have it already
 3. Clone openwhyd's repository: `git clone https://github.com/openwhyd/openwhyd.git`, then `cd openwhyd`
-4. Build and launch Docker processes: `docker-compose up`
+4. Build and launch Docker processes: `docker-compose up --build`
 5. Open [http://localhost:8080](http://localhost:8080) in your web browser => you should see Openwhyd's home page! 🎉
 6. When you're done, shutdown the Docker processes by pressing the `Ctrl-C` key combination in the shell instance where you had run `docker-compose up` (step 4).
 
 Whenever you want to update your local clone of Openwhyd's repository to the latest version, run `git pull` from the `openwhyd` folder where you had cloned the repository (step 3).
 
-Whenever you want to start the Docker processes after shutting them down (step 7), run `docker-compose up` again from the `openwhyd` folder where you had cloned the repository (step 3).
+Whenever you want to start the Docker processes after shutting them down (step 7), run `docker-compose up --build` again from the `openwhyd` folder where you had cloned the repository (step 3).
 
 Whenever you just want to restart Openwhyd while the Docker processes are still running, run `docker-compose restart web` from a shell terminal.
 


### PR DESCRIPTION
What does this PR do / solve?
-----------------------------

A user kindly reported that in order to better protect privacy of user-identifiable data in case of data leak, we should prevent the logging of email addresses and md5 hashes.

Overview of changes
-------------------

- update `request.logToConsole()` to scramble/anonymise values of `email` and `md5` fields
- call the same method in appropriate places where user data is logged
- remove a useless log that contains user data

How to test this PR?
--------------------

1. run the server locally with `docker-compose up`
2. open http://localhost:8080/login in a browser
3. type an email address and password (even fake)
4. the value of your email address and md5 should not be disclosed in the stdout logs of `docker-compose up`:

```
=== Sun, 27 Oct 2019 11:21:10 GMT POST /login (login.handleRequest) {"action":"login","email":"a*********@gmail.com","md5":"<MD5_HASH>"}
fetching user  { email: 'a*********@gmail.com' } ...
```