### PR TITLE
fix(#262): user can add tracks thanks to new google api project for youtube

### DIFF
--- a/app/templates/mainTemplate.js
+++ b/app/templates/mainTemplate.js
@@ -234,7 +234,7 @@ exports.renderWhydFrame = function(html, params) {
     'var DEEZER_APP_ID = 190482;',
     'var DEEZER_CHANNEL_URL = window.location.href.substr(0, window.location.href.indexOf("/", 10)) + "/html/channel.html";',
     'var SOUNDCLOUD_CLIENT_ID = "eb257e698774349c22b0b727df0238ad";',
-    'var YOUTUBE_API_KEY = "AIzaSyBcv9w8c8DVkP_lv7_QAiUlLaY0IbtIQ-M";',
+    'var YOUTUBE_API_KEY = "AIzaSyCRQTfnJJqpruNQk5aySJPX65NXBk8ATdk";',
     'var JAMENDO_CLIENT_ID = "2c9a11b9";',
     '</script>',
     // TODO: move credentials to makeAnalyticsHeading()

--- a/app/templates/postEditV2.html
+++ b/app/templates/postEditV2.html
@@ -15,7 +15,7 @@
 		window.DEEZER_APP_ID = 190482;
 		window.DEEZER_CHANNEL_URL = "{{urlPrefix}}/html/deezer.channel.html".replace(/^http\:/, "https:");
 		window.JAMENDO_CLIENT_ID = "c9cb2a0a";
-		window.YOUTUBE_API_KEY = "AIzaSyCXSFB9V9xQMKL5lWJdtBesrn8f6Mz8NL0";
+		window.YOUTUBE_API_KEY = "AIzaSyBvUtbBd7wYI95B8DVu8VrEV6cR5CzUjFQ";
 
 	</script>
 </head>

--- a/public/html/YoutubePlayerIframe.html
+++ b/public/html/YoutubePlayerIframe.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <script> var YOUTUBE_API_KEY = "AIzaSyCvH2tdCIutSXIAhQ0zc0PBxbI3kjGr8-8"; </script>
+  <script> var YOUTUBE_API_KEY = "AIzaSyBRpwalJ7uBo10a5DH_rYsMTmQM6TifEFI"; </script>
   <script src="//openwhyd.org/js/playem-all.js"></script>
   <script src="//openwhyd.org/js/whydRemotePlayer.js"></script>
 </body>

--- a/public/html/YoutubePlayerIframeLocal.html
+++ b/public/html/YoutubePlayerIframeLocal.html
@@ -8,7 +8,7 @@
 </head>
 
 <body>
-  <script> var YOUTUBE_API_KEY = "AIzaSyC19wW6DlDLK8iehcTwvpMa0N2FgAraHws"; </script>
+  <script> var YOUTUBE_API_KEY = "AIzaSyAkSE-0vsbOeK-GCSqHj6UIhP1OY7yK1OU"; </script>
   <script src="/js/playem-all.js"></script>
   <script src="/js/whydRemotePlayer.js"></script>
 </body>

--- a/public/js/ContentEmbed.js
+++ b/public/js/ContentEmbed.js
@@ -286,7 +286,7 @@ function ContentEmbed() {
     require: function(embedRef, callback) {
       embedRef.img = 'https://i.ytimg.com/vi/' + embedRef.videoId + '/0.jpg';
       var YOUTUBE_API_KEY =
-        YOUTUBE_API_KEY || 'AIzaSyBdV90mnGJVbhN5sOGerSviWpQGLWf9T2o';
+        YOUTUBE_API_KEY || 'AIzaSyAaCiahZyfSTOmQoWkul78t00vO88wUrYQ';
       // TODO: use playemjs instead
       $.getJSON(
         'https://www.googleapis.com/youtube/v3/videos?id=' +

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -13,7 +13,7 @@ if (undefined == window.console)
   };
 
 console.log('-= openwhyd bookmarklet v2.3 =-');
-var YOUTUBE_API_KEY = 'AIzaSyDiqlzCrqhYNLw0ds5j8QGVM7WltwCdOo4';
+var YOUTUBE_API_KEY = 'AIzaSyCIPAYYlBBKqUhl7YdyeCrSXvLFnmDObK8';
 
 (window._initWhydBk = function() {
   var FILENAME = '/js/bookmarklet.js';

--- a/public/js/whydEmbed.js
+++ b/public/js/whydEmbed.js
@@ -4,7 +4,7 @@
  **/
 
 var DEBUG = false, // for soundmanager
-  YOUTUBE_API_KEY = 'AIzaSyCVZGDlhG1-Y5gFgzumVtTKHXYirPgbP7E',
+  YOUTUBE_API_KEY = 'AIzaSyCAZvC5tsGWWA2I2cKKsbfaqjwtXfr4bmg',
   SOUNDCLOUD_CLIENT_ID = 'eb257e698774349c22b0b727df0238ad',
   JAMENDO_CLIENT_ID = '2c9a11b9',
   DEEZER_APP_ID = 190482,

--- a/test/old/snip.tests.js
+++ b/test/old/snip.tests.js
@@ -9,7 +9,7 @@ describe('snip.httpRequest', function() {
   var snip = require('../../app/snip.js');
   //var testRunner = new require("../app/serverTestRunner.js").ServerTestRunner();
 
-  var YOUTUBE_API_KEY = 'AIzaSyD6N68vL5x5lKeFakJNn4wN4Y3oXJ7V8lI';
+  var YOUTUBE_API_KEY = 'AIzaSyDEkfynWx7RpE5Vd0EVubBvl1qq4a6vjio';
   var YOUTUBE_VIDEO_ID = 'aZT8VlTV1YY';
 
   var url =


### PR DESCRIPTION
Closes #262.

## What does this PR do / solve?

Since Google disabled our historic YouTube API Key, on February 20th, users have not been able to add YouTube tracks to their Openwhyd profile. PR #263 did not seem to help. Probably because quotas were broken.

## Overview of changes

- Create a new Google Project to hold new YouTube API Keys.
- Create dedicated YouTube API Keys for each component.

## How to test this PR?

```sh
$ git pull
$ docker-compose up --build --detach
$ nvm use
$ npm install
$ npm run docker:test
```