### PR TITLE
fix(#262): specify dedicated YouTube API key for bookmarklet

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -13,7 +13,7 @@ if (undefined == window.console)
   };
 
 console.log('-= openwhyd bookmarklet v2.3 =-');
-var YOUTUBE_API_KEY = 'AIzaSyCIPAYYlBBKqUhl7YdyeCrSXvLFnmDObK8';
+var YOUTUBE_API_KEY = 'AIzaSyDtDC8PG4axglrMpi-mowvgjedTFfuYCs8'; // associated to dedicated google project "openwhyd-3", because of its high consumption of quota
 
 (window._initWhydBk = function() {
   var FILENAME = '/js/bookmarklet.js';


### PR DESCRIPTION
The bookmarklet (i.e. Chrome Extension) is the what consumes the most quota.

As it makes our new Google Project over-quota, I'm opening a new one just for this.

See https://github.com/openwhyd/openwhyd/issues/262#issuecomment-592952454