### PR TITLE
fix(#262): specify dedicated YouTube API key for postEditV2

### DIFF
--- a/app/templates/postEditV2.html
+++ b/app/templates/postEditV2.html
@@ -15,7 +15,7 @@
 		window.DEEZER_APP_ID = 190482;
 		window.DEEZER_CHANNEL_URL = "{{urlPrefix}}/html/deezer.channel.html".replace(/^http\:/, "https:");
 		window.JAMENDO_CLIENT_ID = "c9cb2a0a";
-		window.YOUTUBE_API_KEY = "AIzaSyBvUtbBd7wYI95B8DVu8VrEV6cR5CzUjFQ";
+		window.YOUTUBE_API_KEY = "AIzaSyCfAzpyy1L0qSAV8qn75gf2U7RkfAAksYE"; // associated to google api project "openwhyd-1", see https://github.com/openwhyd/openwhyd/issues/262
 
 	</script>
 </head>


### PR DESCRIPTION
The track edition/add dialog (i.e. `postEditV2.html`) is the second biggest consumer of our YouTube API usage quota.

As it makes our new Google Developer Project over-quota, I'm opening a new one just for this: `openwhyd-1`.

See https://github.com/openwhyd/openwhyd/issues/262.