### PR TITLE
fix(#269): invalid template caused crash when adding from bookmarklet

### DIFF
--- a/app/templates/postEditV2.html
+++ b/app/templates/postEditV2.html
@@ -106,8 +106,8 @@
 			, title: "{{title}}"
 			, img: "{{img}}"
 			, src: { id: "{{{refUrl}}}".replace(/\&amp\;/g, "&"), name: "{{refTtl}}" }
-{{ #pl }} , pl: { id: "{{id}}", name: "{{{_js_name}}}".replace(/\&amp\;/g, "&") }{{/ pl}}
-	});
+			/*{{#pl}}*/, pl: { id: "{{id}}", name: "{{{_js_name}}}".replace(/\&amp\;/g, "&") }/*{{/pl}}*/
+		});
 	/*]]>*/
 	</script>
 	{{^embedded}}


### PR DESCRIPTION
Closes #269.

Fixes a regression introduced in https://github.com/openwhyd/openwhyd/pull/263/files#diff-d04a3fa73a7dd2a179772cc75555275eR109: a Hogan/Mustache template became invalid after prettier processed it on save.