### PR TITLE
fix(#262): specify dedicated YouTube API key for mainTemplate

### DIFF
--- a/app/templates/mainTemplate.js
+++ b/app/templates/mainTemplate.js
@@ -234,7 +234,7 @@ exports.renderWhydFrame = function(html, params) {
     'var DEEZER_APP_ID = 190482;',
     'var DEEZER_CHANNEL_URL = window.location.href.substr(0, window.location.href.indexOf("/", 10)) + "/html/channel.html";',
     'var SOUNDCLOUD_CLIENT_ID = "eb257e698774349c22b0b727df0238ad";',
-    'var YOUTUBE_API_KEY = "AIzaSyCRQTfnJJqpruNQk5aySJPX65NXBk8ATdk";',
+    'var YOUTUBE_API_KEY = "AIzaSyBNEoOD3NTfPSCgHlUvaVHUOl62rzaOf-E";', // associated to google api project "openwhyd-4", see https://github.com/openwhyd/openwhyd/issues/262
     'var JAMENDO_CLIENT_ID = "2c9a11b9";',
     '</script>',
     // TODO: move credentials to makeAnalyticsHeading()


### PR DESCRIPTION
The YouTube API quota of our main Google Developer Project was reached pretty quickly, causing Openwhyd failing to add tracks from YouTube, and automated E2E tests to fail. (See #262)

I've opened a new Google Developer Project just for the key used in `mainTemplate`: `openwhyd-4`.