### PR TITLE
fix(#262): extend youtube api quota from bookmarklet

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -13,7 +13,11 @@ if (undefined == window.console)
   };
 
 console.log('-= openwhyd bookmarklet v2.3 =-');
-var YOUTUBE_API_KEY = 'AIzaSyDtDC8PG4axglrMpi-mowvgjedTFfuYCs8'; // associated to dedicated google project "openwhyd-3", because of its high consumption of quota
+var YT_KEYS = [
+  'AIzaSyDtDC8PG4axglrMpi-mowvgjedTFfuYCs8', // associated to google project "openwhyd-3"
+  'AIzaSyC8FHehlusUWsbgBV_kE3JSrrNscoAl324' // associated to google project "openwhyd-5"
+];
+var YOUTUBE_API_KEY = YT_KEYS[Math.floor(Math.random() * YT_KEYS.length)];
 
 (window._initWhydBk = function() {
   var FILENAME = '/js/bookmarklet.js';

--- a/test/specs/bookmarklet.tests.js
+++ b/test/specs/bookmarklet.tests.js
@@ -45,6 +45,7 @@ describe('bookmarklet - adding from a youtube track', function() {
     //console.log('client log:', browser.log('client').value.slice(-10));
     //console.log('server log:', browser.log('server').value.slice(-10));
     // TODO: create a re-usable displayLogs() wdio command
+    // Note: browser.log() was renamed as browser.getLogs() in wdio v5
   });
   */
 });

--- a/test/specs/bookmarklet.tests.js
+++ b/test/specs/bookmarklet.tests.js
@@ -28,9 +28,18 @@ describe('bookmarklet - adding from a youtube track', function() {
     $('.whydThumb').waitForExist();
   });
 
+  it(`should list more than 1 track`, function() {
+    browser.waitUntil(() => {
+      const nbThumbs = $$('.whydThumb').length;
+      console.log('number of .whydThumb elements', nbThumbs);
+      // Note: nbThumbs is sometimes stuck to 1, when running Chrome with --headless
+      return nbThumbs > 1;
+    }, 10000);
+  });
+
   /*
   // this code was useful to detect that chrome was not loading insecure/mixed content
-  it(`should output browser log`, function () {
+  it(`should output browser log`, function() {
     console.log('browser log:', browser.log('browser').value.filter(i => i.level === 'SEVERE'));
     //console.log('driver log:', browser.log('driver').value.slice(-10));
     //console.log('client log:', browser.log('client').value.slice(-10));

--- a/test/specs/bookmarklet.tests.js
+++ b/test/specs/bookmarklet.tests.js
@@ -1,8 +1,5 @@
-var assert = require('assert');
-var { URL_PREFIX, ADMIN_USER, TEST_USER } = require('../fixtures.js');
+const { URL_PREFIX, ADMIN_USER } = require('../fixtures.js');
 const webUI = require('../web-ui.js');
-
-const WAIT_DURATION = 10000;
 
 require('../acceptance-cmds.js'); // also checks that openwhyd's server is tested against the test database
 // TODO: make sure that DB was reset before starting Openwhyd's app server


### PR DESCRIPTION
Contributes to #262.

## What does this PR do / solve?

The bookmarklet has been consuming more than 10000 YouTube API Calls per day, which is more than our allowed quota, for now.

## Overview of changes

Alternate between 2 keys, to double our capacity.

## How to test this PR?

`$ npm run docker:seed && node_modules/.bin/wdio wdio.conf.js`