### PR TITLE
fix(#262): bookmarklet to not fetch youtube metadata

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -13,11 +13,6 @@ if (undefined == window.console)
   };
 
 console.log('-= openwhyd bookmarklet v2.3 =-');
-var YT_KEYS = [
-  'AIzaSyDtDC8PG4axglrMpi-mowvgjedTFfuYCs8', // associated to google project "openwhyd-3"
-  'AIzaSyC8FHehlusUWsbgBV_kE3JSrrNscoAl324' // associated to google project "openwhyd-5"
-];
-var YOUTUBE_API_KEY = YT_KEYS[Math.floor(Math.random() * YT_KEYS.length)];
 
 (window._initWhydBk = function() {
   var FILENAME = '/js/bookmarklet.js';
@@ -326,6 +321,7 @@ var YOUTUBE_API_KEY = YT_KEYS[Math.floor(Math.random() * YT_KEYS.length)];
     window.DEEZER_APP_ID = 190482;
     window.DEEZER_CHANNEL_URL = urlPrefix + '/html/deezer.channel.html';
     window.JAMENDO_CLIENT_ID = 'c9cb2a0a';
+    window.YOUTUBE_API_KEY = ''; // see https://github.com/openwhyd/openwhyd/issues/262
     var players = (window._whydPlayers = window._whydPlayers || {
         // playem-all.js must be loaded at that point
         yt: new YoutubePlayer(
@@ -363,6 +359,14 @@ var YOUTUBE_API_KEY = YT_KEYS[Math.floor(Math.random() * YT_KEYS.length)];
         eidSet[parts[0]] = true;
         eidSet[eid] = true;
         if (!player || !player.fetchMetadata) return cb({ eId: eid });
+        else if (player instanceof YoutubePlayer)
+          // we don't fetch metadata from youtube, to save quota (see see https://github.com/openwhyd/openwhyd/issues/262)
+          cb({
+            name: '(YouTube track)',
+            eId: track.eId || eid.substr(0, 4) + track.id,
+            sourceId: playerId,
+            sourceLabel: player.label
+          });
         else
           player.fetchMetadata(url, function(track) {
             if (track) {

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -359,15 +359,19 @@ console.log('-= openwhyd bookmarklet v2.3 =-');
         eidSet[parts[0]] = true;
         eidSet[eid] = true;
         if (!player || !player.fetchMetadata) return cb({ eId: eid });
-        else if (player instanceof YoutubePlayer)
+        else if (player instanceof YoutubePlayer) {
           // we don't fetch metadata from youtube, to save quota (see see https://github.com/openwhyd/openwhyd/issues/262)
+          var id = parts[0].replace('/yt/', '');
           cb({
-            name: '(YouTube track)',
-            eId: track.eId || eid.substr(0, 4) + track.id,
+            id: id,
+            eId: '/yt/' + id,
+            img: 'https://i.ytimg.com/vi/' + id + '/default.jpg',
+            url: 'https://www.youtube.com/watch?v=' + id,
+            title: '(YouTube track)',
             sourceId: playerId,
             sourceLabel: player.label
           });
-        else
+        } else
           player.fetchMetadata(url, function(track) {
             if (track) {
               track = track || {};

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -359,7 +359,7 @@ console.log('-= openwhyd bookmarklet v2.3 =-');
         eidSet[parts[0]] = true;
         eidSet[eid] = true;
         if (!player || !player.fetchMetadata) return cb({ eId: eid });
-        else if (player instanceof YoutubePlayer) {
+        else if (playerId === 'yt') {
           // we don't fetch metadata from youtube, to save quota (see see https://github.com/openwhyd/openwhyd/issues/262)
           var id = parts[0].replace('/yt/', '');
           cb({


### PR DESCRIPTION
Contributes to #262, to save YouTube API quota.