### PR TITLE
refactor: add unit tests for bookmarklet

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -14,7 +14,7 @@ function bookmarklet(window) {
         warn: function() {}
       };
 
-    console.log('-= openwhyd bookmarklet v2.3 =-');
+    console.log('-= openwhyd bookmarklet v2.4 =-');
 
     var FILENAME = '/js/bookmarklet.js';
     var CSS_FILEPATH = '/css/bookmarklet.css';

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -19,3 +19,16 @@ describe('bookmarklet', function() {
     });
   });
 });
+
+/**
+ * How to manually test the bookmarklet, in a web browser
+ * 
+   // 1. Go to the /all page (because it always shows at least one video)
+   window.location.href = 'http://localhost:8080/all';
+   
+   // 2. Load the local bookmarket, using the JavaScript console:
+   window.document.body.appendChild(
+     window.document.createElement('script')
+   ).src = `http://localhost:8080/js/bookmarklet.js?${Date.now()}`;
+ *
+ **/

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -1,0 +1,21 @@
+// const assert = require('assert');
+const { detectTracks } = require('./../../public/js/bookmarklet.js');
+
+describe('bookmarklet', function() {
+  it('should initialize without error', async () => {
+    detectTracks({
+      window: {
+        location: { href: '' },
+        document: {
+          title: '',
+          getElementsByTagName: () => []
+        }
+      },
+      ui: {
+        addSearchThumb: () => {},
+        finish: () => {}
+      },
+      urlDetectors: []
+    });
+  });
+});


### PR DESCRIPTION
Contributes to #262.

## What does this PR do / solve?

As mention in #262 following the reduction of our YouTube API quota, we need to make several changes to the bookmarklet in order to save some quota while keeping a good user experience. E.g. track titles should be extracted from the page instead of queried from YouTube API.

As these changes are quite structural and may introduce bugs in the bookmarklet, and as we don't have time to test it manually after each change, it's time to refactor the code in order to make that code testable by automated unit tests.

This PR is the first step of that refactor: it makes the bookmarklet loadable from Node.js.

## Overview of changes

See the diff, and disable the display of whitespace changes.

- export `detectTracks({ window, ui, urlDetectors })`, `makeFileDetector()` and `makeStreamDetector(players)`
- bump to bookmarklet v2.4 (from v2.3)
- add a first unit test

## How to test this PR?

```sh
$ nvm use
$ node_modules/.bin/mocha test/unit/bookmarklet-tests.js
$ docker-compose up --build -d
$ npm run docker:seed && node_modules/.bin/wdio wdio.conf.js
``` 

Also, you can test the bookmarklet manually, from your web browser, by following the instructions provided in the unit test file: https://github.com/openwhyd/openwhyd/pull/280/files?diff=split&w=1#diff-c8dc146d6906e24b2298327e5628d90aR23