### PR TITLE
fix(bookmarklet): refactor bookmarklet and add tests for #262

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -568,15 +568,20 @@ function bookmarklet(window) {
     var toDetect = new (function ElementStack() {
       // this class holds a collections of elements that potentially reference streamable tracks
       var set = {};
+      function normalize(url) {
+        if (typeof url === 'string' && !/^javascript\:/.test(url)) {
+          return url.split('#')[0];
+        } else {
+          return undefined;
+        }
+      }
       this.push = function(elt) {
         var url =
           elt &&
-          (elt.eId ||
-            unwrapFacebookLink(elt.href || elt.src || elt.data || ''));
-        if (url && typeof url === 'string') {
-          url = url.split('#')[0];
-          if (url && url.indexOf('javascript:') != 0) set[url] = elt;
-        }
+          normalize(
+            elt.eId || unwrapFacebookLink(elt.href || elt.src || elt.data || '')
+          );
+        if (url) set[url] = elt;
       };
       this.getSortedArray = function() {
         var eIds = [],

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -408,6 +408,20 @@ function bookmarklet(window) {
   // - DomElement objects must have a href or src field.
   // - DomElement and Track objects will be passed to urlDetectors, to complete their metadata if needed.
   var DETECTORS = [
+    function detectYouTubePageTrack(window) {
+      if (/ - YouTube$/.test(window.document.title) === false) return null;
+      var videoElement = window.document.getElementsByTagName(
+        'ytd-watch-flexy'
+      )[0];
+      if (!videoElement) return null;
+      var videoId = videoElement.getAttribute('video-id');
+      if (!videoId || window.location.href.indexOf(videoId) == -1) return null;
+      return [
+        {
+          searchQuery: window.document.title.replace(/ - YouTube$/, '')
+        }
+      ];
+    },
     function detectPandoraTrack(window) {
       if (window.location.href.indexOf('pandora.com') == -1) return null;
       var artist = getNodeText(

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -14,7 +14,7 @@ function bookmarklet(window) {
         warn: function() {}
       };
 
-    console.log('-= openwhyd bookmarklet v2.4 =-');
+    console.log('-= openwhyd bookmarklet v2.5 =-');
 
     var FILENAME = '/js/bookmarklet.js';
     var CSS_FILEPATH = '/css/bookmarklet.css';

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -542,7 +542,8 @@ function bookmarklet(window) {
 
     function whenDone() {
       console.info('finished detecting tracks!');
-      if (!ui.nbTracks) ui.addSearchThumb({ name: window.document.title });
+      if (!ui.nbTracks)
+        ui.addSearchThumb({ searchQuery: window.document.title });
       ui.finish();
     }
 

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -348,6 +348,8 @@ function bookmarklet(window) {
     });
   }
 
+  // players = { playerId -> { getEid(), fetchMetadata() } }
+  // returns detectPlayemStreams(url, cb)
   function makeStreamDetector(players) {
     var eidSet = {}; // to prevent duplicates
     function getPlayerId(url) {
@@ -401,8 +403,10 @@ function bookmarklet(window) {
     };
   }
 
-  // each detector is called once, without parameters, and returns a list of element objects
-  // (with fields {searchQuery:}, {href:} or {src:}) to extract streams from.
+  // Each detector is called once per web page and returns a list of Query, DomElement and/or Track objects.
+  // - Query objects must have a searchQuery field. They will be passed as-is to ui.addSearchThumb()
+  // - DomElement objects must have a href or src field.
+  // - DomElement and Track objects will be passed to urlDetectors, to complete their metadata if needed.
   var DETECTORS = [
     function detectPandoraTrack(window) {
       if (window.location.href.indexOf('pandora.com') == -1) return null;

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -61,7 +61,7 @@ describe('bookmarklet', () => {
     const results = await detectTracksAsPromise({ window });
     assert.equal(typeof results, 'object');
     assert.equal(results.length, 1);
-    assert.equal(results[0].name, window.document.title);
+    assert.equal(results[0].searchQuery, window.document.title);
   });
 
   it('should return the track title from a Spotify page', async () => {

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -1,6 +1,13 @@
 const assert = require('assert');
 const bookmarklet = require('./../../public/js/bookmarklet.js');
 
+const YOUTUBE_VIDEO = {
+  id: 'uWB8plk9sXk',
+  title: 'Harissa - Tierra',
+  img: `https://i.ytimg.com/vi/uWB8plk9sXk/default.jpg`,
+  url: `https://www.youtube.com/watch?v=uWB8plk9sXk`
+};
+
 const makeWindow = ({ url = '', title = '' }) => ({
   location: { href: url },
   document: {
@@ -51,7 +58,7 @@ describe('bookmarklet', () => {
 
     describe('detectPlayemStreams()', () => {
       it('should return nothing when no players were provided', async () => {
-        const url = 'https://www.youtube.com/watch?v=uWB8plk9sXk';
+        const { url } = YOUTUBE_VIDEO;
         const players = {};
         const detectPlayemStreams = bookmarklet.makeStreamDetector(players);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
@@ -59,41 +66,37 @@ describe('bookmarklet', () => {
       });
 
       it('should return a track from its URL when a simple detector was provided', async () => {
+        const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
-        const videoId = 'uWB8plk9sXk';
-        const url = `https://www.youtube.com/watch?v=${videoId}`;
         const detectors = {
-          [playerId]: { getEid: () => videoId }
+          [playerId]: { getEid: () => YOUTUBE_VIDEO.id }
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
         assert.equal(typeof track, 'object');
-        assert.equal(track.eId, `/${playerId}/${videoId}`);
+        assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
       });
 
       it('should return a track from its URL when a complete detector was provided', async () => {
+        const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
-        const videoId = 'uWB8plk9sXk';
-        const videoTitle = 'Harissa - Tierra';
-        const videoImg = `https://i.ytimg.com/vi/${videoId}/default.jpg`;
-        const url = `https://www.youtube.com/watch?v=${videoId}`;
         const detectors = {
           [playerId]: {
-            getEid: () => videoId,
+            getEid: () => YOUTUBE_VIDEO.id,
             fetchMetadata: () => ({
-              id: videoId,
-              title: videoTitle,
-              img: videoImg
+              id: YOUTUBE_VIDEO.id,
+              title: YOUTUBE_VIDEO.title,
+              img: YOUTUBE_VIDEO.img
             })
           }
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
         assert.equal(typeof track, 'object');
-        assert.equal(track.id, videoId);
-        assert.equal(track.title, '(YouTube track)'); // TODO: should be videoTitle instead, see #262
-        assert.equal(track.img, videoImg);
-        assert.equal(track.eId, `/${playerId}/${videoId}`);
+        assert.equal(track.id, YOUTUBE_VIDEO.id);
+        assert.equal(track.title, '(YouTube track)'); // TODO: should be YOUTUBE_VIDEO.title instead, see #262
+        assert.equal(track.img, YOUTUBE_VIDEO.img);
+        assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
         assert.equal(track.sourceId, playerId);
       });
     });

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -66,7 +66,11 @@ describe('bookmarklet', () => {
 
   it('should return the track title from a Spotify page', async () => {
     const songTitle = 'Dummy Song';
-    const window = makeWindow({ title: `${songTitle} - Spotify` });
+    const window = makeWindow({
+      url:
+        'https://open.spotify.com/album/0EX4lJA3CFaKIvjFJyYIpe?highlight=spotify:track:0P41Qf51RcEWId6W6RykV4',
+      title: `${songTitle} - Spotify`
+    });
     const results = await detectTracksAsPromise({ window });
     assert.equal(typeof results, 'object');
     assert.equal(results.length, 1);

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -48,6 +48,7 @@ const detectTracksAsPromise = ({ window, urlDetectors = [] }) =>
         get nbTracks() {
           return tracks.length;
         },
+        addThumb: track => tracks.push(track),
         addSearchThumb: track => tracks.push(track),
         finish: () => resolve(tracks)
       },
@@ -86,7 +87,29 @@ describe('bookmarklet', () => {
     const results = await detectTracksAsPromise({ window });
     assert.equal(typeof results, 'object');
     assert.equal(results.length, 1);
-    assert.equal(results[0].searchQuery, YOUTUBE_VIDEO.title);
+    assert.equal(results[0].name, YOUTUBE_VIDEO.title);
+  });
+
+  it('should return the track metadata from a YouTube page when its detector is provided', async () => {
+    const window = makeWindow({
+      url: YOUTUBE_VIDEO.url,
+      title: `${YOUTUBE_VIDEO.title} - YouTube`,
+      elementsByTagName: YOUTUBE_VIDEO.elementsByTagName
+    });
+    const playerId = 'yt';
+    const detectors = { [playerId]: YOUTUBE_VIDEO.detector };
+    const results = await detectTracksAsPromise({
+      window,
+      urlDetectors: [bookmarklet.makeStreamDetector(detectors)]
+    });
+    assert.equal(typeof results, 'object');
+    assert.equal(results.length, 1);
+    const track = results[0];
+    assert.equal(track.id, YOUTUBE_VIDEO.id);
+    assert.equal(track.title, '(YouTube track)'); // TODO: should be YOUTUBE_VIDEO.title instead, see #262
+    assert.equal(track.img, YOUTUBE_VIDEO.img);
+    assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
+    assert.equal(track.sourceId, playerId);
   });
 
   describe('makeStreamDetector()', () => {

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -5,7 +5,15 @@ const YOUTUBE_VIDEO = {
   id: 'uWB8plk9sXk',
   title: 'Harissa - Tierra',
   img: `https://i.ytimg.com/vi/uWB8plk9sXk/default.jpg`,
-  url: `https://www.youtube.com/watch?v=uWB8plk9sXk`
+  url: `https://www.youtube.com/watch?v=uWB8plk9sXk`,
+  elementsByTagName: {
+    'ytd-watch-flexy': [
+      {
+        role: 'main',
+        'video-id': 'uWB8plk9sXk'
+      }
+    ]
+  }
 };
 
 const makeWindow = ({ url = '', title = '' }) => ({
@@ -48,6 +56,20 @@ describe('bookmarklet', () => {
     assert.equal(typeof results, 'object');
     assert.equal(results.length, 1);
     assert.equal(results[0].searchQuery, songTitle);
+  });
+
+  it('should return the track url and title from a YouTube page', async () => {
+    const window = makeWindow({
+      url: YOUTUBE_VIDEO.url,
+      title: `${YOUTUBE_VIDEO.title} - YouTube`,
+      elementsByTagName: YOUTUBE_VIDEO.elementsByTagName
+    });
+    const results = await detectTracksAsPromise({ window });
+    console.log(results);
+    assert.equal(typeof results, 'object');
+    assert.equal(results.length, 1);
+    assert.equal(results[0].src, YOUTUBE_VIDEO.url);
+    assert.equal(results[0].searchQuery, YOUTUBE_VIDEO.title);
   });
 
   describe('makeStreamDetector()', () => {

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -159,12 +159,14 @@ describe('bookmarklet', () => {
 });
 
 /**
- * How to manually test the bookmarklet, in a web browser
+ * How to manually test the bookmarklet
  * 
-   // 1. Go to the /all page (because it always shows at least one video)
-   window.location.href = 'http://localhost:8080/all';
+   // 1. Make sure that openwhyd is running locally
+
+   // 2. In your web browser, open a web page that contains videos
    
-   // 2. Load the local bookmarket, using the JavaScript console:
+   // 3. In the page's JavaScript console, Load the local bookmarket:
+   
    window.document.body.appendChild(
      window.document.createElement('script')
    ).src = `http://localhost:8080/js/bookmarklet.js?${Date.now()}`;

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -80,10 +80,8 @@ describe('bookmarklet', () => {
       elementsByTagName: YOUTUBE_VIDEO.elementsByTagName
     });
     const results = await detectTracksAsPromise({ window });
-    console.log(results);
     assert.equal(typeof results, 'object');
     assert.equal(results.length, 1);
-    assert.equal(results[0].src, YOUTUBE_VIDEO.url);
     assert.equal(results[0].searchQuery, YOUTUBE_VIDEO.title);
   });
 

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -6,6 +6,14 @@ const YOUTUBE_VIDEO = {
   title: 'Harissa - Tierra',
   img: `https://i.ytimg.com/vi/uWB8plk9sXk/default.jpg`,
   url: `https://www.youtube.com/watch?v=uWB8plk9sXk`,
+  detector: {
+    getEid: () => YOUTUBE_VIDEO.id,
+    fetchMetadata: () => ({
+      id: YOUTUBE_VIDEO.id,
+      title: YOUTUBE_VIDEO.title,
+      img: YOUTUBE_VIDEO.img
+    })
+  },
   elementsByTagName: {
     'ytd-watch-flexy': [
       {
@@ -16,11 +24,18 @@ const YOUTUBE_VIDEO = {
   }
 };
 
-const makeWindow = ({ url = '', title = '' }) => ({
+const makeElement = attributes => ({
+  ...attributes,
+  getAttribute: attr => attributes[attr]
+});
+
+const makeWindow = ({ url = '', title = '', elementsByTagName = {} }) => ({
   location: { href: url },
   document: {
     title,
-    getElementsByTagName: () => []
+    getElementsByTagName: tagName =>
+      (elementsByTagName[tagName] || []).map(makeElement)
+    // TODO: getElementsByClassName()
   }
 });
 
@@ -91,7 +106,7 @@ describe('bookmarklet', () => {
         const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
         const detectors = {
-          [playerId]: { getEid: () => YOUTUBE_VIDEO.id }
+          [playerId]: { getEid: YOUTUBE_VIDEO.detector.getEid }
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
@@ -103,14 +118,7 @@ describe('bookmarklet', () => {
         const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
         const detectors = {
-          [playerId]: {
-            getEid: () => YOUTUBE_VIDEO.id,
-            fetchMetadata: () => ({
-              id: YOUTUBE_VIDEO.id,
-              title: YOUTUBE_VIDEO.title,
-              img: YOUTUBE_VIDEO.img
-            })
-          }
+          [playerId]: YOUTUBE_VIDEO.detector
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));


### PR DESCRIPTION
Contributes to #262. Follow up of #280.

## What does this PR do / solve?

As mentioned in #262 following the reduction of our YouTube API quota, we need to make several changes to the bookmarklet in order to save some quota while keeping a good user experience. E.g. track titles should be extracted from the page instead of queried from YouTube API.

As these changes are quite structural and may introduce bugs in the bookmarklet, and as we don't have time to test it manually after each change, it's time to refactor the code in order to make that code testable by automated unit tests.

This PR is the second step of that refactor: it enables adaptive metadata enrichment for the page itself (e.g. youtube track page), while preventing duplicates in the results.

## Overview of changes

See the diff, and disable the display of whitespace changes.

- add `detectYouTubePageTrack()`
- group ui calls
- bump to bookmarklet v2.5 (from v2.4)
- add unit tests

## How to test this PR?

```sh
$ nvm use
$ node_modules/.bin/mocha test/unit/bookmarklet-tests.js
$ docker-compose up --build -d
$ npm run docker:seed && node_modules/.bin/wdio wdio.conf.js
``` 

Also, you can test the bookmarklet manually, from your web browser, by following the instructions provided in the unit test file.