### PR TITLE
feat(bookmarklet): extract youtube track names from page

### DIFF
--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -251,7 +251,7 @@ function bookmarklet(window) {
   }
 
   function getNodeText(node) {
-    return node.innerText || node.textContent;
+    return (node.innerText || node.textContent || '').trim().split('\n')[0]; // keep just the first line of text (useful for suggested YouTube links that include stats on following lines)
   }
 
   function unwrapFacebookLink(src) {
@@ -553,11 +553,7 @@ function bookmarklet(window) {
         if (track) {
           track.url = url;
           track.title =
-            track.title ||
-            element.text ||
-            element.textNode ||
-            element.title ||
-            element.alt; // || track.eId || url || p.label;
+            track.title || getNodeText(element) || element.title || element.alt; // || track.eId || url || p.label;
           if (track.sourceLabel)
             track.sourceLogo =
               urlPrefix +
@@ -590,7 +586,7 @@ function bookmarklet(window) {
         }
       }
       function size(elt) {
-        return (elt.name || elt.text || '').length;
+        return (elt.name || getNodeText(elt) || '').length;
       }
       this.has = function(url) {
         var normalized = normalize(url);

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -675,6 +675,7 @@ function bookmarklet(window) {
     });
   } else {
     return {
+      YOUTUBE_PLAYER,
       detectTracks,
       makeFileDetector,
       makeStreamDetector

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -544,10 +544,7 @@ function bookmarklet(window) {
     function detectTrack(url, element, cb) {
       var remainingUrlDetectors = urlDetectors.slice();
       (function processNext() {
-        if (!remainingUrlDetectors.length) {
-          cb();
-        } else {
-          //console.log('- trying detector ' + (urlDetectors.length-1));
+        if (!remainingUrlDetectors.length) return cb();
           remainingUrlDetectors.shift()(
             url,
             function(track) {
@@ -556,7 +553,6 @@ function bookmarklet(window) {
             },
             element
           );
-        }
       })();
     }
 

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -539,9 +539,9 @@ function bookmarklet(window) {
   ];
 
   function detectTracks({ window, ui, urlDetectors }) {
-    // an url-based detector must callback with a track Object (with fields: {id, eId, title, img}) as parameter, if detected
+    // an urlDetector must callback with a track Object (with fields: {id, eId, title, img}) as parameter, if detected
 
-    function detectTrack(url, cb, element) {
+    function detectTrack(url, element, cb) {
       var remainingUrlDetectors = urlDetectors.slice();
       (function processNext() {
         if (!remainingUrlDetectors.length) {
@@ -560,13 +560,12 @@ function bookmarklet(window) {
       })();
     }
 
-    function detectEmbed(e, cb) {
-      var url = e.eId || unwrapFacebookLink(e.href || e.src || e.data || '');
-      //console.log(url);
-      if (!url) return cb && cb();
-      detectTrack(
-        url,
-        function(track) {
+    function detectEmbed(element, cb) {
+      var url =
+        element.eId ||
+        unwrapFacebookLink(element.href || element.src || element.data || '');
+      if (!url) return cb();
+      detectTrack(url, element, function(track) {
           if (track && track.title) {
             track.url = url;
             //track.title = track.title || e.textNode || e.title || e.alt || track.eId || url; // || p.label;
@@ -578,9 +577,7 @@ function bookmarklet(window) {
                 '.png';
           }
           cb(track);
-        },
-        e
-      );
+      });
     }
 
     function whenDone(searchThumbs) {

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -327,18 +327,39 @@ function bookmarklet(window) {
     };
   }
 
+  var YOUTUBE_PLAYER = {
+    getEid: function(url) {
+      // code imported from playem-all
+      if (
+        /(youtube\.com\/(v\/|embed\/|(?:.*)?[\?\&]v=)|youtu\.be\/)([a-zA-Z0-9_\-]+)/.test(
+          url
+        ) ||
+        /^\/yt\/([a-zA-Z0-9_\-]+)/.test(url) ||
+        /youtube\.com\/attribution_link\?.*v\%3D([^ \%]+)/.test(url) ||
+        /youtube.googleapis.com\/v\/([a-zA-Z0-9_\-]+)/.test(url)
+      )
+        return RegExp.lastParen;
+    },
+    fetchMetadata: function(url, callback) {
+      var id = this.getEid(url);
+      callback({
+        id: id,
+        eId: '/yt/' + id,
+        img: 'https://i.ytimg.com/vi/' + id + '/default.jpg',
+        url: 'https://www.youtube.com/watch?v=' + id,
+        playerLabel: 'Youtube'
+      });
+    }
+  };
+
   function initPlayemPlayers() {
     window.SOUNDCLOUD_CLIENT_ID = 'eb257e698774349c22b0b727df0238ad';
     window.DEEZER_APP_ID = 190482;
     window.DEEZER_CHANNEL_URL = urlPrefix + '/html/deezer.channel.html';
     window.JAMENDO_CLIENT_ID = 'c9cb2a0a';
-    window.YOUTUBE_API_KEY = ''; // see https://github.com/openwhyd/openwhyd/issues/262
     return (window._whydPlayers = window._whydPlayers || {
+      yt: YOUTUBE_PLAYER, // instead of new YoutubePlayer(...), to save API quota (see #262)
       // playem-all.js must be loaded at that point
-      yt: new YoutubePlayer(
-        {},
-        { playerContainer: window.document.getElementById('videocontainer') }
-      ),
       sc: new SoundCloudPlayer({}),
       vi: new VimeoPlayer({}),
       dm: new DailymotionPlayer({}),

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -489,7 +489,6 @@ function bookmarklet(window) {
         var bcPrefix = '/bc/' + bc.url.split('//')[1].split('.')[0] + '/';
         toDetect = bc.trackinfo.map(function(tr) {
           if (tr.file) {
-            //console.log("-------------FILE! =>", tr.file);
             var streamUrl = tr.file[Object.keys(tr.file)[0]];
             return {
               href: streamUrl,
@@ -552,7 +551,6 @@ function bookmarklet(window) {
           remainingUrlDetectors.shift()(
             url,
             function(track) {
-              //console.log(' => ' + typeof track + ' ' + JSON.stringify(track))
               if (track && track.id) cb(track);
               else processNext();
             },
@@ -631,7 +629,7 @@ function bookmarklet(window) {
 
     DETECTORS.map(function(detectFct) {
       var results = detectFct(window) || [];
-      console.info('-----' + detectFct.name, '=>', results);
+      console.info('-----' + detectFct.name, '=>', results.length);
       results.map(function(result) {
         toDetect.push(result);
       });

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -402,6 +402,8 @@ function bookmarklet(window) {
       // 4. try to return the track with enriched metadata
       player.fetchMetadata(url, function(track) {
         if (!track) return cb();
+        element = element || {};
+        track.title = track.title || element.name; // i.e. element.name could have been extracted from the page by one of the DETECTORS
         track.eId = track.eId || eid.substr(0, 4) + track.id; // || eid;
         track.sourceId = playerId;
         track.sourceLabel = player.label;

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -584,6 +584,9 @@ function bookmarklet(window) {
           return undefined;
         }
       }
+      function size(elt) {
+        return (elt.name || elt.text || '').length;
+      }
       this.has = function(url) {
         var normalized = normalize(url);
         return normalized && !!set[normalized];
@@ -594,7 +597,11 @@ function bookmarklet(window) {
           normalize(
             elt.eId || unwrapFacebookLink(elt.href || elt.src || elt.data || '')
           );
-        if (url) set[url] = elt;
+        if (!url) return;
+        var existingElt = set[url];
+        if (!existingElt || size(elt) > size(existingElt)) {
+          set[url] = elt;
+        }
       };
       this.getSortedArray = function() {
         var eIds = [],

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -550,9 +550,14 @@ function bookmarklet(window) {
         unwrapFacebookLink(element.href || element.src || element.data || '');
       if (!url) return cb();
       detectTrack(url, element, function(track) {
-        if (track && track.title) {
+        if (track) {
           track.url = url;
-          //track.title = track.title || e.textNode || e.title || e.alt || track.eId || url; // || p.label;
+          track.title =
+            track.title ||
+            element.text ||
+            element.textNode ||
+            element.title ||
+            element.alt; // || track.eId || url || p.label;
           if (track.sourceLabel)
             track.sourceLogo =
               urlPrefix +

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -104,6 +104,36 @@ describe('bookmarklet', () => {
     assert.equal(track.sourceId, playerId);
   });
 
+  it(`should return the page's track with metadata from a YouTube page when the same track is also listed in the page with less metadata`, async () => {
+    const window = makeWindow({
+      url: YOUTUBE_VIDEO.url,
+      title: `${YOUTUBE_VIDEO.title} - YouTube`,
+      elementsByTagName: {
+        ...YOUTUBE_VIDEO.elementsByTagName,
+        a: [
+          {
+            class: 'ytp-title-channel-name',
+            href: 'https://www.youtube.com/watch?v=uWB8plk9sXk' // note: in a youtube page, this attribute is actually empty, but the browser returns the current page's URL
+          }
+        ]
+      }
+    });
+    const playerId = 'yt';
+    const detectors = { [playerId]: bookmarklet.YOUTUBE_PLAYER };
+    const results = await detectTracksAsPromise({
+      window,
+      urlDetectors: [bookmarklet.makeStreamDetector(detectors)]
+    });
+    assert.equal(typeof results, 'object');
+    assert.equal(results.length, 1);
+    const track = results[0];
+    assert.equal(track.id, YOUTUBE_VIDEO.id);
+    assert.equal(track.title, YOUTUBE_VIDEO.title);
+    assert.equal(track.img, YOUTUBE_VIDEO.img);
+    assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
+    assert.equal(track.sourceId, playerId);
+  });
+
   describe('makeStreamDetector()', () => {
     it('should return a function', () => {
       const detectPlayemStreams = bookmarklet.makeStreamDetector();

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -110,7 +110,7 @@ describe('bookmarklet', () => {
         a: [
           {
             href: YOUTUBE_VIDEO.url,
-            text: YOUTUBE_VIDEO.title
+            textContent: YOUTUBE_VIDEO.title
           }
         ]
       }
@@ -131,13 +131,13 @@ describe('bookmarklet', () => {
     assert.equal(track.sourceId, playerId);
   });
 
-  it(`should return a track without the expected name when that track was found as a link from a YouTube page`, async () => {
+  it(`should return a track with the expected name when that track was found as a link from a YouTube page`, async () => {
     const window = makeWindow({
       elementsByTagName: {
         a: [
           {
             href: YOUTUBE_VIDEO.url,
-            text: `\n${YOUTUBE_VIDEO.title}\nHarissa Quartet\nVerified\n•287K views\n`
+            textContent: `\n${YOUTUBE_VIDEO.title}\nHarissa Quartet\nVerified\n•287K views\n`
           }
         ]
       }

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -6,14 +6,6 @@ const YOUTUBE_VIDEO = {
   title: 'Harissa - Tierra',
   img: `https://i.ytimg.com/vi/uWB8plk9sXk/default.jpg`,
   url: `https://www.youtube.com/watch?v=uWB8plk9sXk`,
-  detector: {
-    getEid: () => YOUTUBE_VIDEO.id,
-    fetchMetadata: () => ({
-      id: YOUTUBE_VIDEO.id,
-      title: YOUTUBE_VIDEO.title,
-      img: YOUTUBE_VIDEO.img
-    })
-  },
   elementsByTagName: {
     'ytd-watch-flexy': [
       {
@@ -97,7 +89,7 @@ describe('bookmarklet', () => {
       elementsByTagName: YOUTUBE_VIDEO.elementsByTagName
     });
     const playerId = 'yt';
-    const detectors = { [playerId]: YOUTUBE_VIDEO.detector };
+    const detectors = { [playerId]: bookmarklet.YOUTUBE_PLAYER };
     const results = await detectTracksAsPromise({
       window,
       urlDetectors: [bookmarklet.makeStreamDetector(detectors)]
@@ -131,7 +123,7 @@ describe('bookmarklet', () => {
         const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
         const detectors = {
-          [playerId]: { getEid: YOUTUBE_VIDEO.detector.getEid }
+          [playerId]: { getEid: bookmarklet.YOUTUBE_PLAYER.getEid }
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
@@ -143,7 +135,15 @@ describe('bookmarklet', () => {
         const { url } = YOUTUBE_VIDEO;
         const playerId = 'yt';
         const detectors = {
-          [playerId]: YOUTUBE_VIDEO.detector
+          [playerId]: {
+            getEid: () => YOUTUBE_VIDEO.id,
+            fetchMetadata: (url, callback) =>
+              callback({
+                id: YOUTUBE_VIDEO.id,
+                title: YOUTUBE_VIDEO.title,
+                img: YOUTUBE_VIDEO.img
+              })
+          }
         };
         const detectPlayemStreams = bookmarklet.makeStreamDetector(detectors);
         const track = await new Promise(cb => detectPlayemStreams(url, cb));

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -131,6 +131,33 @@ describe('bookmarklet', () => {
     assert.equal(track.sourceId, playerId);
   });
 
+  it(`should return a track without the expected name when that track was found as a link from a YouTube page`, async () => {
+    const window = makeWindow({
+      elementsByTagName: {
+        a: [
+          {
+            href: YOUTUBE_VIDEO.url,
+            text: `\n${YOUTUBE_VIDEO.title}\nHarissa Quartet\nVerified\n•287K views\n`
+          }
+        ]
+      }
+    });
+    const playerId = 'yt';
+    const detectors = { [playerId]: bookmarklet.YOUTUBE_PLAYER };
+    const results = await detectTracksAsPromise({
+      window,
+      urlDetectors: [bookmarklet.makeStreamDetector(detectors)]
+    });
+    assert.equal(typeof results, 'object');
+    assert.equal(results.length, 1);
+    const track = results[0];
+    assert.equal(track.id, YOUTUBE_VIDEO.id);
+    assert.equal(track.title, YOUTUBE_VIDEO.title);
+    assert.equal(track.img, YOUTUBE_VIDEO.img);
+    assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
+    assert.equal(track.sourceId, playerId);
+  });
+
   it(`should return the page's track with metadata from a YouTube page when the same track is also listed in the page with less metadata`, async () => {
     const window = makeWindow({
       url: YOUTUBE_VIDEO.url,

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -104,19 +104,38 @@ describe('bookmarklet', () => {
     assert.equal(track.sourceId, playerId);
   });
 
+  it(`should return a track with metadata from a YouTube page that lists that track as a link`, async () => {
+    const window = makeWindow({
+      elementsByTagName: {
+        a: [
+          {
+            href: YOUTUBE_VIDEO.url,
+            text: YOUTUBE_VIDEO.title
+          }
+        ]
+      }
+    });
+    const playerId = 'yt';
+    const detectors = { [playerId]: bookmarklet.YOUTUBE_PLAYER };
+    const results = await detectTracksAsPromise({
+      window,
+      urlDetectors: [bookmarklet.makeStreamDetector(detectors)]
+    });
+    assert.equal(typeof results, 'object');
+    assert.equal(results.length, 1);
+    const track = results[0];
+    assert.equal(track.id, YOUTUBE_VIDEO.id);
+    assert.equal(track.title, YOUTUBE_VIDEO.title);
+    assert.equal(track.img, YOUTUBE_VIDEO.img);
+    assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
+    assert.equal(track.sourceId, playerId);
+  });
+
   it(`should return the page's track with metadata from a YouTube page when the same track is also listed in the page with less metadata`, async () => {
     const window = makeWindow({
       url: YOUTUBE_VIDEO.url,
       title: `${YOUTUBE_VIDEO.title} - YouTube`,
-      elementsByTagName: {
-        ...YOUTUBE_VIDEO.elementsByTagName,
-        a: [
-          {
-            class: 'ytp-title-channel-name',
-            href: 'https://www.youtube.com/watch?v=uWB8plk9sXk' // note: in a youtube page, this attribute is actually empty, but the browser returns the current page's URL
-          }
-        ]
-      }
+      elementsByTagName: YOUTUBE_VIDEO.elementsByTagName
     });
     const playerId = 'yt';
     const detectors = { [playerId]: bookmarklet.YOUTUBE_PLAYER };

--- a/test/unit/bookmarklet-tests.js
+++ b/test/unit/bookmarklet-tests.js
@@ -98,7 +98,7 @@ describe('bookmarklet', () => {
     assert.equal(results.length, 1);
     const track = results[0];
     assert.equal(track.id, YOUTUBE_VIDEO.id);
-    assert.equal(track.title, '(YouTube track)'); // TODO: should be YOUTUBE_VIDEO.title instead, see #262
+    assert.equal(track.title, YOUTUBE_VIDEO.title);
     assert.equal(track.img, YOUTUBE_VIDEO.img);
     assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
     assert.equal(track.sourceId, playerId);
@@ -149,7 +149,7 @@ describe('bookmarklet', () => {
         const track = await new Promise(cb => detectPlayemStreams(url, cb));
         assert.equal(typeof track, 'object');
         assert.equal(track.id, YOUTUBE_VIDEO.id);
-        assert.equal(track.title, '(YouTube track)'); // TODO: should be YOUTUBE_VIDEO.title instead, see #262
+        assert.equal(track.title, YOUTUBE_VIDEO.title);
         assert.equal(track.img, YOUTUBE_VIDEO.img);
         assert.equal(track.eId, `/${playerId}/${YOUTUBE_VIDEO.id}`);
         assert.equal(track.sourceId, playerId);


### PR DESCRIPTION
Contributes to #262. Follow up of #281 and #282.

## What does this PR do / solve?

After YouTube reduced our API quota, we resorted to specifying "(YouTube track)" as the title of tracked extracted from YouTube pages using the bookmarklet, in order to save some quota.

This PR intends to determine the actual name of the track by extracting text from the DOM, and therefore to get rid of those "(YouTube track)" titles on newly added tracks.

## Overview of changes

- completely get rid of forced "(YouTube track)" titles 🥳
- add feat: "return a track with metadata from a YouTube page that lists that track as a link"
- add feat: "return a track with the expected name when that track was found as a link from a YouTube page" (i.e. remove noise from title)
- add feat: "return the page's track with metadata from a YouTube page when the same track is also listed in the page with less metadata"
- rename `detectPlayemStreams()` --> `detectPlayableStreams()` + integrate `YOUTUBE_PLAYER` (partially imported from PlayemJS, without the API query part) in the bookmarket, and use it also from tests => first step in progressively getting rid of Playem for track detection
- normalize the way text is extracted from DOM
- cleaning up logs from bookmarklet
- simplify logic and make code a little bit more readable overall

## How to test this PR?

```sh
$ nvm use
$ node_modules/.bin/mocha test/unit/bookmarklet-tests.js
$ docker-compose up --build -d
$ npm run docker:seed && node_modules/.bin/wdio wdio.conf.js
``` 

Also, you can test the bookmarklet manually, from your web browser, by following the instructions provided in the unit test file.