### PR TITLE
test(#295): add non-regression test for pagination

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,7 @@ if (process.env.NODE_ENV === "production") {
 
 var DB_INIT_SCRIPTS = [
   './config/initdb.js'
-  //'./config/initdb_team.js', // creates an admin user => should not be run on production!
+  //'./config/initdb_testing.js', // creates an admin user => should not be run on production!
 ];
 
 function makeColorConsole(fct, color) {

--- a/config/initdb_testing.js
+++ b/config/initdb_testing.js
@@ -1,9 +1,9 @@
-// Usage: this file should be run by mongo's CLI:
-// $ mongo openwhyd_data whydDB/initdb_team.js
+// Usage: this file should be run by runShellScript() or by mongo's CLI:
+// $ mongo openwhyd_data initdb_testing.js
 
 //db = db.getSiblingDB("openwhyd_data"); //connect("localhost:27017/whyd_music");
 
-print('upserting openwhyd team users ...');
+print('upserting openwhyd testing users ...');
 
 db.user.update(
   { _id: ObjectId('000000000000000000000001') },

--- a/config/initdb_testing.js
+++ b/config/initdb_testing.js
@@ -20,4 +20,314 @@ db.user.update(
   { upsert: true }
 );
 
+db.user.update(
+  { _id: ObjectId('000000000000000000000002') },
+  {
+    $set: {
+      email: 'dummy@openwhyd.org',
+      handle: 'dummy',
+      name: 'dummy',
+      img: '/images/blank_user.gif',
+      pwd: '21232f297a57a5a743894a0e4a801fc3' /* password = "admin" */
+    }
+  },
+  { upsert: true }
+);
+
+print('upserting openwhyd testing posts ...');
+
+db.post.update(
+  { _id: ObjectId(`0`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #0`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`1`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #1`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`2`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #2`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`3`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #3`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`4`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #4`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`5`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #5`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`6`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #6`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`7`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #7`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`8`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #8`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`9`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #9`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`10`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #10`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`11`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #11`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`12`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #12`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`13`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #13`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`14`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #14`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`15`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #15`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`16`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #16`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`17`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #17`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`18`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #18`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`19`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #19`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
+db.post.update(
+  { _id: ObjectId(`20`.padStart(24, '0')) },
+  {
+    $set: {
+      name: `Fake track #20`,
+      eId: '/yt/Wch3gJG2GJ4' /* 1-second video, from YouTube */,
+      uId: '000000000000000000000002' /* user id of dummy user defined above */,
+      uNm: 'dummy',
+      img: '/images/cover-track.png'
+    }
+  },
+  { upsert: true }
+);
+
 print('done! :-)');

--- a/cypress/fixtures/users.js
+++ b/cypress/fixtures/users.js
@@ -8,6 +8,15 @@
     pwd: 'admin',
     md5: '21232f297a57a5a743894a0e4a801fc3'
   },
+  dummy: {
+    id: '000000000000000000000002',
+    email: 'dummy@openwhyd.org',
+    name: 'dummy',
+    username: 'dummy',
+    password: 'admin',
+    pwd: 'admin',
+    md5: '21232f297a57a5a743894a0e4a801fc3'
+  },
   testUser: {
     email: 'test-user@openwhyd.org',
     name: 'Test User',

--- a/cypress/integration/acceptance.spec.ts
+++ b/cypress/integration/acceptance.spec.ts
@@ -1,0 +1,19 @@
+/// <reference types="Cypress" />
+
+context('Openwhyd', () => {
+  it('should allow user to login', () => {
+    cy.visit('/');
+
+    cy.get('#signin') // https://on.cypress.io/interacting-with-elements
+      .click()
+      .get('.btnCreateAccount')
+      .should('be.visible');
+
+    cy.fixture('users.js').then(({ admin }) => {
+      cy.get('input[name=email]').type(admin.email); // https://on.cypress.io/type
+      cy.get('input[name=password]').type(admin.password);
+      cy.get('form').submit();
+      cy.get('#loginDiv .username').should('have.text', admin.name); // https://youtu.be/5XQOK0v_YRE?t=1430
+    });
+  });
+});

--- a/cypress/integration/acceptance.spec.ts
+++ b/cypress/integration/acceptance.spec.ts
@@ -15,5 +15,7 @@ context('Openwhyd', () => {
       cy.get('form').submit();
       cy.get('#loginDiv .username').should('have.text', admin.name); // https://youtu.be/5XQOK0v_YRE?t=1430
     });
+
+    cy.wait(3000); // to check that we don't get any runtime javascript error
   });
 });

--- a/cypress/integration/bookmarklet.spec.ts
+++ b/cypress/integration/bookmarklet.spec.ts
@@ -2,20 +2,7 @@
 
 context('Openwhyd', () => {
   before('login', () => {
-    cy.visit('/');
-
-    cy.get('#signin') // https://on.cypress.io/interacting-with-elements
-      .click()
-      .get('.btnCreateAccount')
-      .should('be.visible');
-
-    cy.fixture('users.js').then(({ admin }) => {
-      cy.get('input[name=email]').type(admin.email); // https://on.cypress.io/type
-      cy.get('input[name=password]').type(admin.password);
-      cy.get('form').submit();
-      cy.get('#loginDiv .username').should('have.text', admin.name); // https://youtu.be/5XQOK0v_YRE?t=1430
-    });
-    // ... or send the login request directly to the API, as in https://youtu.be/5XQOK0v_YRE?t=1430
+    cy.loginAsAdmin();
   });
 
   it('can add a track from a youtube page', () => {

--- a/cypress/integration/stream.spec.ts
+++ b/cypress/integration/stream.spec.ts
@@ -2,7 +2,7 @@
 
 context('Openwhyd stream', () => {
   // TODO: can load next page of the global stream
-  it('can load next page of tracks when user not logged in', () => {
+  it('can load next page of profile when user not logged in', () => {
     cy.visit('/u/000000000000000000000002'); // will show profile page of user 'dummy' defined in initdb_testing.js
 
     cy.get('.post h2')
@@ -31,10 +31,31 @@ context('Openwhyd stream', () => {
     */
   });
 
-  it('can load next page of tracks when user is logged in', () => {
+  it('can load next page of profile when user is logged in', () => {
     cy.loginAsAdmin();
 
     cy.visit('/u/000000000000000000000002'); // will show profile page of user 'dummy' defined in initdb_testing.js
+
+    cy.get('.post h2')
+      .should('have.length', 20)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #1')
+      .should('not.include.text', 'Fake track #0');
+
+    cy.get('.btnLoadMore').click();
+
+    cy.get('.post h2')
+      .should('have.length', 21)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #0');
+  });
+
+  it('can load next page of stream when user is logged in', () => {
+    cy.fixture('users.js').then(({ dummy }) => {
+      cy.login(dummy);
+    });
+
+    cy.visit('/'); // will show the home/stream of the user 'dummy' defined in initdb_testing.js
 
     cy.get('.post h2')
       .should('have.length', 20)

--- a/cypress/integration/stream.spec.ts
+++ b/cypress/integration/stream.spec.ts
@@ -1,0 +1,34 @@
+/// <reference types="Cypress" />
+
+context('Openwhyd stream', () => {
+  // TODO: can load next page of the global stream
+  // TODO: can load next page of tracks when user is logged in
+  it('can load next page of tracks when user not logged in', () => {
+    cy.visit('/u/000000000000000000000002'); // will show profile page of user 'dummy' defined in initdb_testing.js
+
+    cy.get('.post h2')
+      .should('have.length', 20)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #1')
+      .should('not.include.text', 'Fake track #0');
+
+    cy.get('.btnLoadMore').click();
+
+    cy.get('.post h2')
+      .should('have.length', 21)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #0');
+
+    /*
+    // should list the main track of the page
+    cy.get('.whydThumb', { timeout: 10000 }).should(function($thumbs) {
+      cy.log('coucou', ($thumbs || []).length); // problem: always zero...
+      for (const i = 0; i < ($thumbs || []).length; i++) {
+        cy.log(i, $thumbs[i]);
+        const style = Cypress.$($thumbs[i]).attr('style');
+        expect(style).to.include(youtubeId);
+      }
+    });
+    */
+  });
+});

--- a/cypress/integration/stream.spec.ts
+++ b/cypress/integration/stream.spec.ts
@@ -2,7 +2,6 @@
 
 context('Openwhyd stream', () => {
   // TODO: can load next page of the global stream
-  // TODO: can load next page of tracks when user is logged in
   it('can load next page of tracks when user not logged in', () => {
     cy.visit('/u/000000000000000000000002'); // will show profile page of user 'dummy' defined in initdb_testing.js
 
@@ -30,5 +29,24 @@ context('Openwhyd stream', () => {
       }
     });
     */
+  });
+
+  it('can load next page of tracks when user is logged in', () => {
+    cy.loginAsAdmin();
+
+    cy.visit('/u/000000000000000000000002'); // will show profile page of user 'dummy' defined in initdb_testing.js
+
+    cy.get('.post h2')
+      .should('have.length', 20)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #1')
+      .should('not.include.text', 'Fake track #0');
+
+    cy.get('.btnLoadMore').click();
+
+    cy.get('.post h2')
+      .should('have.length', 21)
+      .should('include.text', 'Fake track #20')
+      .should('include.text', 'Fake track #0');
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -8,17 +8,16 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 //
-//
-// -- This is a parent command --
+
+Cypress.Commands.add('login', ({ email, md5 }) => {
+  cy.request('GET', `/login?action=login&ajax=1&email=${email}&md5=${md5}`);
+  cy.request('POST', `/consent`);
+});
+
 Cypress.Commands.add('loginAsAdmin', () => {
   cy.fixture('users.js').then(({ admin }) => {
-    cy.request(
-      'GET',
-      `/login?action=login&ajax=1&email=${admin.email}&md5=${admin.md5}`
-    );
-    cy.request('POST', `/consent`);
+    cy.login(admin);
   });
-  // ... or send the login request directly to the API, as in https://youtu.be/5XQOK0v_YRE?t=1430
 });
 
 //

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,8 +10,23 @@
 //
 //
 // -- This is a parent command --
-// Cypress.Commands.add("login", (email, password) => { ... })
-//
+Cypress.Commands.add('loginAsAdmin', (email, password) => {
+  cy.visit('/');
+
+  cy.get('#signin') // https://on.cypress.io/interacting-with-elements
+    .click()
+    .get('.btnCreateAccount')
+    .should('be.visible');
+
+  cy.fixture('users.js').then(({ admin }) => {
+    cy.get('input[name=email]').type(admin.email); // https://on.cypress.io/type
+    cy.get('input[name=password]').type(admin.password);
+    cy.get('form').submit();
+    // cy.get('#loginDiv .username').should('have.text', admin.name); // https://youtu.be/5XQOK0v_YRE?t=1430
+  });
+  // ... or send the login request directly to the API, as in https://youtu.be/5XQOK0v_YRE?t=1430
+});
+
 //
 // -- This is a child command --
 // Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -10,19 +10,13 @@
 //
 //
 // -- This is a parent command --
-Cypress.Commands.add('loginAsAdmin', (email, password) => {
-  cy.visit('/');
-
-  cy.get('#signin') // https://on.cypress.io/interacting-with-elements
-    .click()
-    .get('.btnCreateAccount')
-    .should('be.visible');
-
+Cypress.Commands.add('loginAsAdmin', () => {
   cy.fixture('users.js').then(({ admin }) => {
-    cy.get('input[name=email]').type(admin.email); // https://on.cypress.io/type
-    cy.get('input[name=password]').type(admin.password);
-    cy.get('form').submit();
-    // cy.get('#loginDiv .username').should('have.text', admin.name); // https://youtu.be/5XQOK0v_YRE?t=1430
+    cy.request(
+      'GET',
+      `/login?action=login&ajax=1&email=${admin.email}&md5=${admin.md5}`
+    );
+    cy.request('POST', `/consent`);
   });
   // ... or send the login request directly to the API, as in https://youtu.be/5XQOK0v_YRE?t=1430
 });

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,0 +1,15 @@
+/// <reference types="cypress" />
+
+// To let TypeScript compiler know that we have added a custom command and have IntelliSense working
+// (see https://github.com/cypress-io/cypress-example-todomvc#cypress-intellisense)
+
+declare namespace Cypress {
+  interface Chainable<Subject> {
+    /**
+     * Login as the admin user defined in initdb_testing.js
+     * @example
+     * cy.loginAsAdmin()
+     */
+    loginAsAdmin(): Chainable<any>;
+  }
+}

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -6,6 +6,12 @@
 declare namespace Cypress {
   interface Chainable<Subject> {
     /**
+     * Login, given an email address and md5 password hash
+     * @example
+     * cy.loginAsAdmin()
+     */
+    login({ email, md5 }: { email: string; md5: string }): Chainable<any>;
+    /**
      * Login as the admin user defined in initdb_testing.js
      * @example
      * cy.loginAsAdmin()

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -76,7 +76,7 @@ If you don't want to use Docker (or can't), you can follow these instructions.
 - Make sure that `make` and `g++` are installed (required for building npm binaries, _I had to do [this](https://github.com/fedwiki/wiki/issues/46) and [this](https://www.digitalocean.com/community/questions/node-gyp-rebuild-fails-on-install)_)
 - Make sure that a MongoDB server is running
 - Make sure that the necessary environment variables are defined (see below)
-- Make sure that the database is initialized (by running `mongo openwhyd_data config/initdb.js` and `mongo openwhyd_data config/initdb_team.js`)
+- Make sure that the database is initialized (by running `mongo openwhyd_data config/initdb.js` and `mongo openwhyd_data config/initdb_testing.js`)
 - Make sure that dependencies are installed (`npm install`)
 - If you want notifications to be pushed to your iPhone app, make sure that Apple Push Notification Service (APNS) certificates are copied to `/config/apns` with the following filenames: `aps_dev.cert.pem`, `aps_dev.key.pem`, `aps_prod.cert.pem`, `aps_prod.key.pem`, and `Dev_Whyd.mobileprovision`. (you can test them using `test_apns.sh`)
 

--- a/test/reset-test-db.js
+++ b/test/reset-test-db.js
@@ -3,7 +3,7 @@ var async = require('async');
 
 var DB_INIT_SCRIPTS = [
   './config/initdb.js',
-  './config/initdb_team.js' // creates an admin user => should not be run on production!
+  './config/initdb_testing.js' // creates an admin user => should not be run on production!
 ];
 
 var params = (process.appParams = {


### PR DESCRIPTION
In PR #296, we found out that a reformat of our front-end js files including mustache/hogan blocks caused runtime errors which prevented the "load more" button to work as expected.

In order to prevent future regressions on pagination and runtime errors, this PR adds Cypress tests.

Note: It's expected that the Cypress tests fails, until we merge #296.