### PR TITLE
fix(docker): ignore log files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 */*/node_modules
 */*/*.log
 */*/db
+/*.log
 /*.out
 /*.pid
 /*.err


### PR DESCRIPTION
Contributes to #309. 

Log files were found while checking the contents of our Docker image, in PR #306. => Let's ignore them.