### PR TITLE
fix(ui): redirect error when landing on rankings page

### DIFF
--- a/app/controllers/discover.js
+++ b/app/controllers/discover.js
@@ -364,21 +364,26 @@ exports.handleRequest = function (request, reqParams, response) {
       processData[reqParams.ajax](reqParams, render);
     } else render({ error: 'invalid call' });
   } else {
-    templateLoader.loadTemplate(TEMPLATE_FILE, function (template) {
-      render({
-        html: mainTemplate.renderWhydPage({
-          bodyClass: 'pgDiscover ' + TAB_CLASSES[reqParams.tab],
-          loggedUser: reqParams.loggedUser,
-          content: template.render({
-            isLogged: !!reqParams.loggedUser,
-            isAdmin: reqParams.loggedUser
-              ? request.isUserAdmin(reqParams.loggedUser)
-              : false
+    if (!TAB_CLASSES[reqParams.tab]) {
+      console.log('unknown tab => redirecting');
+      response.temporaryRedirect('/discover/featured'); // before: /users
+    } else {
+      templateLoader.loadTemplate(TEMPLATE_FILE, function (template) {
+        render({
+          html: mainTemplate.renderWhydPage({
+            bodyClass: 'pgDiscover ' + TAB_CLASSES[reqParams.tab],
+            loggedUser: reqParams.loggedUser,
+            content: template.render({
+              isLogged: !!reqParams.loggedUser,
+              isAdmin: reqParams.loggedUser
+                ? request.isUserAdmin(reqParams.loggedUser)
+                : false
+            })
           })
-        })
+        });
+        //analytics.addVisit(reqParams.loggedUser, request.url);
       });
-      //analytics.addVisit(reqParams.loggedUser, request.url);
-    });
+    }
   }
 };
 


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #21 

## What does this PR do / solve?

Prevent redirect error and allow page to load for guest users
![Screenshot from 2020-04-07 11-59-52](https://user-images.githubusercontent.com/13477167/78708799-8ac1c080-78c7-11ea-82ee-f4165c3d9d10.png)


<!--
| Type a high-level summary.
|
| * Explain Why and How you're proposing these changes.
| * Explain anything non trivial that you're doing.
| * Anticipate the reviewer's question to save time.
| * Don't forget to provide context to reviewers.
-->

## Overview of changes

I removed some conditions redirecting the user from 
https://openwhyd.org/discover/ranking to https://openwhyd.org/discover/featured.

Since this redirect was causing the page to throw an error instead of actually loading the redirected page I would think it is best to just load the rankings page. Then the user can click on the featured tab to go the the featured page.

<!--
| If your PR introduces visual changes, add a screenshot.
| If your PR produces some output, add a screenshot/sample.
| If your PR fixes something, add a before/after sample/screenshot.
-->

## How to test this PR?

The page is now loading when a guest user goes to https://openwhyd.org/discover/ranking

<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
