### PR TITLE
fix(CI): Force cypress v3.8.3 on the Docker Workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Run Cypress E2E tests
         run: |
-          npx cypress run --config pluginsFile=false # because plugins/index.js requires typescript, which is not installed in this production image
+          npx cypress@3.8.3 run --config pluginsFile=false # because plugins/index.js requires typescript, which is not installed in this production image
 
 # To publish the Docker image from here, see https://github.com/openwhyd/openwhyd/pull/308/commits/1eacaa98885789642ba0073c9bb4d822021f0d95#diff-12a86cef0c4707531fdbabac3e38cb2aR36


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #333 .

## What does this PR do / solve?

Forcing cypress version 3.8.3 on the Docker Workflow with npx