### PR TITLE
fix: Only checking the PR title

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

## What does this PR do / solve?

Forcing the CI to only check the PR title instead of checking all of the commits in the PR
