### PR TITLE
fix(linter): Re-enable linting of JS files in VSCode

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
   ],
   "plugins": ["prettier", "@typescript-eslint"],
   "parserOptions": {
-    "project": "./tsconfig.json",
+    "project": "tsconfig.json",
     "ecmaVersion": 2019
   },
   "rules": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,3 @@
 {
-  "include": ["node_modules/cypress", "cypress/*/*.ts", "cypress/*/*.d.ts"]
+  "include": ["**/*.ts", "**/*.d.ts", "**/*.js"]
 }


### PR DESCRIPTION
Fixes the following "Problem" listed by Visual Studio code, when opening a JS file:

> Parsing error: "parserOptions.project" has been set for @typescript-eslint/parser.
> The file does not match your project config: test/unit/notif-tests.js.
> The file must be included in at least one of the projects provided.

![image](https://user-images.githubusercontent.com/531781/92353996-bef11580-f0e1-11ea-8693-14b84c8f7620.png)
