### PR TITLE
fix: Remove Barelog / Productfeed

### DIFF
--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -179,37 +179,8 @@
           >
         </li>
       </ul>
-      <p>
-        Openwhyd is maintained collaboratively,<br />under the MIT License.
-        <a
-          id="barelog-trigger"
-          href="#"
-          style="position: relative; padding-right: 22px"
-          >What's new?</a
-        ><span id="headway-changelog-badge" />
-      </p>
+      <p>Openwhyd is maintained collaboratively,<br />under the MIT License.</p>
     </div>
-
-    <!-- this script activates the "What's new?" link -->
-    <script>
-      (function (b, a, r, e, l, o, g) {
-        (o = a.createElement(r)), (g = a.getElementsByTagName(r)[0]);
-        o.async = 1;
-        o.src = e;
-        g.parentNode.insertBefore(o, g);
-        o.addEventListener('load', function () {
-          setTimeout(function () {
-            Barelog(options);
-          }, 50);
-        });
-      })(window, document, 'script', 'https://cdn.productfeed.app/widget.js');
-
-      var options = {
-        id: 't8nrxyyfogwt',
-        trigger: '#productfeed-trigger',
-      };
-    </script>
-    <!-- end of "What's new?" link -->
   </div>
   <!-- END RIGHT BAR-->
   {{/user}} {{#playlist}}{{#inContest}}


### PR DESCRIPTION
The "what's new" link does not work anymore. Rather than fixing something that does not seem to be useful, let's remove it.