### PR TITLE
fix(ui): Never-ending refresh of full stream

### DIFF
--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -27,20 +27,6 @@
     </style>
     <script>
       /*<![CDATA[*/
-      $(document).ready(function () {
-        function loadTop() {
-          console.log('polling new tracks...');
-          $.get(window.prevPageUrl, function (data) {
-            $('.posts > .post').first().before(data);
-            setTimeout(function () {
-              console.log('refreshing...');
-              //window.whydPlayer.updateTracks();
-              window.whydPlayer.refresh(); // in order to re-position the video currently being played
-            }, 200);
-          });
-        }
-        setInterval(loadTop, 4000);
-      });
       function openVideo() {
         openHtmlDialog(
           '<iframe src="//player.vimeo.com/video/53666841?autoplay=1" width="560" height="315" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>'


### PR DESCRIPTION
Contributes to #397.

## What does this PR do / solve?

A `polling new tracks...` logs appearing repeatedly after visiting the full stream (`/all`), even after navigating. Causing a lot of requests to our API.

## Overview of changes

Remove the auto-refresh of the "full stream".
