### PR TITLE
fix(bookmarklet): Remove PlayemJS from bookmarklet

### DIFF
--- a/public/js/bookmarkletUI.ts
+++ b/public/js/bookmarkletUI.ts
@@ -278,28 +278,6 @@ if (typeof exports === 'undefined') {
       return this;
     }
 
-    // Additional detectors
-
-    function initPlayemPlayers(playemUrl, callback) {
-      window.SOUNDCLOUD_CLIENT_ID = 'eb257e698774349c22b0b727df0238ad';
-      window.DEEZER_APP_ID = 190482;
-      window.DEEZER_CHANNEL_URL = urlPrefix + '/html/deezer.channel.html';
-      window.JAMENDO_CLIENT_ID = 'c9cb2a0a';
-      window.YOUTUBE_API_KEY = '';
-      include(playemUrl, function () {
-        // playem-all.js must be loaded at that point
-        callback({
-          // yt: new YoutubePlayer(...) should be replaced by openwhydYouTubeExtractor, to save API quota (see #262)
-          sc: new window.SoundCloudPlayer({}),
-          vi: new window.VimeoPlayer({}),
-          dm: new window.DailymotionPlayer({}),
-          dz: new window.DeezerPlayer({}),
-          bc: new window.BandcampPlayer({}),
-          ja: new window.JamendoPlayer({}),
-        });
-      });
-    }
-
     // Start up
 
     const urlPrefix = findScriptHost(FILENAME) || 'https://openwhyd.org',
@@ -307,27 +285,17 @@ if (typeof exports === 'undefined') {
 
     console.info('loading bookmarklet stylesheet...');
     include(urlPrefix + CSS_FILEPATH + urlSuffix);
-    console.info('loading PlayemJS...');
-    const playemFile = /openwhyd\.org/.test(urlPrefix)
-      ? 'playem-min.js'
-      : 'playem-all.js';
-    const playemUrl = urlPrefix + '/js/' + playemFile + urlSuffix;
-    initPlayemPlayers(playemUrl, function (players) {
-      const bookmarklet = makeBookmarklet({
-        pageDetectors: openwhydBkPageDetectors, // defined in bookmarkletPageDetectors.ts
-      });
-      const allPlayers = Object.assign(
-        {
-          yt: openwhydYouTubeExtractor, // alternative to YoutubePlayer from PlayemJS, to save API quota (see #262)
-        },
-        players
-      );
-      bookmarklet.detectTracks({
-        window,
-        ui: BkUi(),
-        urlDetectors: [makeFileDetector(), makeStreamDetector(allPlayers)], // defined in bookmarkletUrlDetectors.ts
-        urlPrefix,
-      });
+    const bookmarklet = makeBookmarklet({
+      pageDetectors: openwhydBkPageDetectors, // defined in bookmarkletPageDetectors.ts
+    });
+    const allPlayers = {
+      yt: openwhydYouTubeExtractor, // alternative to YoutubePlayer from PlayemJS, to save API quota (see #262)
+    };
+    bookmarklet.detectTracks({
+      window,
+      ui: BkUi(),
+      urlDetectors: [makeFileDetector(), makeStreamDetector(allPlayers)], // defined in bookmarkletUrlDetectors.ts
+      urlPrefix,
     });
   })();
 }


### PR DESCRIPTION
## What does this PR do / solve?

PlayemJS has been maintained for Openwhyd, to play and detect tracks, by communicating with the APIs of the streaming sources we support.

While PlayemJS has supported more sources than most alternative players we have found online, its codebase has become hard to maintain, so it suffers from a lack of updates, which lead to numerous problems taking a lot of time and effort to fix: e.g. #272, #262, #192, #190, #143, #132, #128, #16...

In order to simplify Openwhyd's codebase and make it easier for us to replace PlayemJS with an alternative, let's start by trying to remove it from the bookmarklet and see if anybody misses it from there.
