### PR TITLE
fix: sort playlist feature bug

### DIFF
--- a/public/js/whyd.js
+++ b/public/js/whyd.js
@@ -12,7 +12,7 @@ window.goToPage = function (url) {
 };
 
 // prevents bug in firefox 3
-if (undefined == window.console) window.console = { log: function () { } }; // eslint-disable-line @typescript-eslint/no-empty-function
+if (undefined == window.console) window.console = { log: function () {} }; // eslint-disable-line @typescript-eslint/no-empty-function
 
 /* utility functions */
 
@@ -275,12 +275,12 @@ function onNewPost(whydPost) {
 
   showMessage(
     "Successfully added track to <a target='_blank' href='" +
-    '/u/' +
-    p.uId +
-    (p.pl ? '/playlist/' + p.pl.id : '') +
-    "'>" +
-    encodeHtmlEntities((p.pl || {}).name || 'your tracks') +
-    '</a>'
+      '/u/' +
+      p.uId +
+      (p.pl ? '/playlist/' + p.pl.id : '') +
+      "'>" +
+      encodeHtmlEntities((p.pl || {}).name || 'your tracks') +
+      '</a>'
   );
 
   try {
@@ -329,14 +329,14 @@ function _renderUserInList(user, liHandler) {
         .css(
           'background-image',
           "url('" +
-          (user.img || '/img/u/' + user.id) +
-          "?width=100&amp;height=100')"
+            (user.img || '/img/u/' + user.id) +
+            "?width=100&amp;height=100')"
         )
         .click(
           user.thumbClickHandler ||
-          function () {
-            $(this).parent().find('a.userLink').click();
-          }
+            function () {
+              $(this).parent().find('a.userLink').click();
+            }
         )
     )
     .append(
@@ -393,7 +393,7 @@ function _commentDeleteHandler() {
   var $post = $comment.closest('.post');
   var $html = $(
     '<div><p>Do you want to permanently delete this comment?</p></div>' +
-    '<span class="btnDelete greenButton">Delete</span>'
+      '<span class="btnDelete greenButton">Delete</span>'
   );
   openJqueryDialog($html, 'dlgDeleteComment');
   $('.dlgDeleteComment .btnDelete').click(function () {
@@ -747,20 +747,20 @@ window.sharePost = function (pId) {
       '<div class="pointe"></div>',
       '<div class="sharing">',
       '<iframe class="twitter-share-button twitter-count-horizontal" src="//platform.twitter.com/widgets/tweet_button.1347008535.html#_=1347354227175&amp;count=horizontal&amp;id=twitter-widget-0&amp;lang=en&amp;size=m&amp;text=' +
-      encodeURIComponent('♫ ' + post.name /*+ " " + postUrl*/) +
-      '&amp;url=' +
-      encodeURIComponent(postUrl) +
-      '&amp;via=open_whyd&amp;original_referer=' +
-      encodeURIComponent(window.location.href) +
-      '" title="Twitter Tweet Button" data-twttr-rendered="true" allowtransparency="true" frameborder="0" scrolling="no"></iframe>',
+        encodeURIComponent('♫ ' + post.name /*+ " " + postUrl*/) +
+        '&amp;url=' +
+        encodeURIComponent(postUrl) +
+        '&amp;via=open_whyd&amp;original_referer=' +
+        encodeURIComponent(window.location.href) +
+        '" title="Twitter Tweet Button" data-twttr-rendered="true" allowtransparency="true" frameborder="0" scrolling="no"></iframe>',
       '<iframe class="fblikeBtn" src="//www.facebook.com/plugins/like.php?href=' +
-      encodeURIComponent(postUrl) +
-      '&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;font&amp;colorscheme=light&amp;height=21&amp;appId=169250156435902" scrolling="no" frameborder="0" allowTransparency="true"></iframe>',
+        encodeURIComponent(postUrl) +
+        '&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;font&amp;colorscheme=light&amp;height=21&amp;appId=169250156435902" scrolling="no" frameborder="0" allowTransparency="true"></iframe>',
       '</div>',
       '<p>Permalink</p>',
       '<input type="text" value="' +
-      postUrl +
-      '" readonly="readonly" onclick="this.focus();this.select();(this.innerText.createTextRange()).execCommand(\'Copy\');"></input>',
+        postUrl +
+        '" readonly="readonly" onclick="this.focus();this.select();(this.innerText.createTextRange()).execCommand(\'Copy\');"></input>',
       '</div>',
     ].join('\n');
 
@@ -912,11 +912,11 @@ $(document).ready(function () {
   // init search bar
 
   var noResultsYet = function (q) {
-    return /*$(*/[
+    return /*$(*/ [
       '<ul class="showAllResults loading">',
       '<li><a href="/search?q=' +
-      encodeURIComponent(q) +
-      '" target="_blank">Show all results...</a></li>',
+        encodeURIComponent(q) +
+        '" target="_blank">Show all results...</a></li>',
       '</ul>',
     ].join('\n') /*).ajaxify()[0]*/;
   };
@@ -950,13 +950,13 @@ $(document).ready(function () {
           return !tracks.length
             ? resultsHtml || ''
             : (resultsHtml || '</ul>').replace(
-              '</ul>',
-              '</ul>' +
-              "<ul class='resultCategory'>" +
-              '<div>Tracks</div>' +
-              tracks.map(renderTrack).join('\n') +
-              '</ul>'
-            );
+                '</ul>',
+                '</ul>' +
+                  "<ul class='resultCategory'>" +
+                  '<div>Tracks</div>' +
+                  tracks.map(renderTrack).join('\n') +
+                  '</ul>'
+              );
         }
         if (/^https?:\/\//.test(query))
           whydPlayer.fetchTrackByUrl(query, function (track) {
@@ -967,10 +967,10 @@ $(document).ready(function () {
               track.eId
                 ? prependExternalTracks([track])
                 : '<div class="noResults">' +
-                "<p>Sorry, we don't recognize this URL...</p>" +
-                '<p>We currently support URLs from Youtube, Soundcloud and Vimeo.</p>' +
-                '<p>Please install and try <a href="/button">our "Add Track" button</a> from that page.</p>' +
-                '</div>',
+                    "<p>Sorry, we don't recognize this URL...</p>" +
+                    '<p>We currently support URLs from Youtube, Soundcloud and Vimeo.</p>' +
+                    '<p>Please install and try <a href="/button">our "Add Track" button</a> from that page.</p>' +
+                    '</div>',
               false
             );
             // TODO: send this URL back to whyd/playemJS team
@@ -1165,12 +1165,12 @@ $(document).ready(function () {
           $menuChildren.filter(activeSelector).removeClass(activeClass);
           $menuChildren = $menuChildren.has(
             'a[href^="' +
-            relativeUrl +
-            '"],a[href^="/' +
-            relativeUrl +
-            '"],a[href^="' +
-            url +
-            '"]'
+              relativeUrl +
+              '"],a[href^="/' +
+              relativeUrl +
+              '"],a[href^="' +
+              url +
+              '"]'
           );
           if ($menuChildren.length === 1) {
             $menuChildren.addClass(activeClass);
@@ -1333,9 +1333,9 @@ window.sortPlaylists = function (sortType) {
   if (allPlaylists.length > 2) {
     allPlaylists.forEach((playlist, index) => {
       if (playlist.dataset.playlistname) {
-
         //store playlist name in a variable and add index to create a unique key in allPlaylistsObject
-        const playlistNameKey = playlist.dataset.playlistname.toLowerCase() + index;
+        const playlistNameKey =
+          playlist.dataset.playlistname.toLowerCase() + index;
 
         if (!playlist.dataset.index) {
           playlist.setAttribute('data-index', index);
@@ -1357,17 +1357,16 @@ window.sortPlaylists = function (sortType) {
       sortedPlaylistObjectKeys = Object.keys(allPlaylistsObject).sort(
         //if sorting by date first convert index key string to a number with '+' then compare to sort in ascending order.
         function (firstPlaylistIndex, secondPlaylistIndex) {
-          return (+firstPlaylistIndex) - (+secondPlaylistIndex);
+          return +firstPlaylistIndex - +secondPlaylistIndex;
         }
       );
     } else {
       sortedPlaylistObjectKeys = Object.keys(allPlaylistsObject).sort();
     }
 
-    sortedPlaylistObjectKeys
-      .forEach((playlist) =>
-        playlistsFragment.appendChild(allPlaylistsObject[playlist])
-      );
+    sortedPlaylistObjectKeys.forEach((playlist) =>
+      playlistsFragment.appendChild(allPlaylistsObject[playlist])
+    );
 
     playlistsContainer.appendChild(playlistsFragment);
   }

--- a/public/js/whyd.js
+++ b/public/js/whyd.js
@@ -12,7 +12,7 @@ window.goToPage = function (url) {
 };
 
 // prevents bug in firefox 3
-if (undefined == window.console) window.console = { log: function () {} }; // eslint-disable-line @typescript-eslint/no-empty-function
+if (undefined == window.console) window.console = { log: function () { } }; // eslint-disable-line @typescript-eslint/no-empty-function
 
 /* utility functions */
 
@@ -275,12 +275,12 @@ function onNewPost(whydPost) {
 
   showMessage(
     "Successfully added track to <a target='_blank' href='" +
-      '/u/' +
-      p.uId +
-      (p.pl ? '/playlist/' + p.pl.id : '') +
-      "'>" +
-      encodeHtmlEntities((p.pl || {}).name || 'your tracks') +
-      '</a>'
+    '/u/' +
+    p.uId +
+    (p.pl ? '/playlist/' + p.pl.id : '') +
+    "'>" +
+    encodeHtmlEntities((p.pl || {}).name || 'your tracks') +
+    '</a>'
   );
 
   try {
@@ -329,14 +329,14 @@ function _renderUserInList(user, liHandler) {
         .css(
           'background-image',
           "url('" +
-            (user.img || '/img/u/' + user.id) +
-            "?width=100&amp;height=100')"
+          (user.img || '/img/u/' + user.id) +
+          "?width=100&amp;height=100')"
         )
         .click(
           user.thumbClickHandler ||
-            function () {
-              $(this).parent().find('a.userLink').click();
-            }
+          function () {
+            $(this).parent().find('a.userLink').click();
+          }
         )
     )
     .append(
@@ -393,7 +393,7 @@ function _commentDeleteHandler() {
   var $post = $comment.closest('.post');
   var $html = $(
     '<div><p>Do you want to permanently delete this comment?</p></div>' +
-      '<span class="btnDelete greenButton">Delete</span>'
+    '<span class="btnDelete greenButton">Delete</span>'
   );
   openJqueryDialog($html, 'dlgDeleteComment');
   $('.dlgDeleteComment .btnDelete').click(function () {
@@ -747,20 +747,20 @@ window.sharePost = function (pId) {
       '<div class="pointe"></div>',
       '<div class="sharing">',
       '<iframe class="twitter-share-button twitter-count-horizontal" src="//platform.twitter.com/widgets/tweet_button.1347008535.html#_=1347354227175&amp;count=horizontal&amp;id=twitter-widget-0&amp;lang=en&amp;size=m&amp;text=' +
-        encodeURIComponent('♫ ' + post.name /*+ " " + postUrl*/) +
-        '&amp;url=' +
-        encodeURIComponent(postUrl) +
-        '&amp;via=open_whyd&amp;original_referer=' +
-        encodeURIComponent(window.location.href) +
-        '" title="Twitter Tweet Button" data-twttr-rendered="true" allowtransparency="true" frameborder="0" scrolling="no"></iframe>',
+      encodeURIComponent('♫ ' + post.name /*+ " " + postUrl*/) +
+      '&amp;url=' +
+      encodeURIComponent(postUrl) +
+      '&amp;via=open_whyd&amp;original_referer=' +
+      encodeURIComponent(window.location.href) +
+      '" title="Twitter Tweet Button" data-twttr-rendered="true" allowtransparency="true" frameborder="0" scrolling="no"></iframe>',
       '<iframe class="fblikeBtn" src="//www.facebook.com/plugins/like.php?href=' +
-        encodeURIComponent(postUrl) +
-        '&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;font&amp;colorscheme=light&amp;height=21&amp;appId=169250156435902" scrolling="no" frameborder="0" allowTransparency="true"></iframe>',
+      encodeURIComponent(postUrl) +
+      '&amp;layout=button_count&amp;show_faces=false&amp;width=100&amp;action=like&amp;font&amp;colorscheme=light&amp;height=21&amp;appId=169250156435902" scrolling="no" frameborder="0" allowTransparency="true"></iframe>',
       '</div>',
       '<p>Permalink</p>',
       '<input type="text" value="' +
-        postUrl +
-        '" readonly="readonly" onclick="this.focus();this.select();(this.innerText.createTextRange()).execCommand(\'Copy\');"></input>',
+      postUrl +
+      '" readonly="readonly" onclick="this.focus();this.select();(this.innerText.createTextRange()).execCommand(\'Copy\');"></input>',
       '</div>',
     ].join('\n');
 
@@ -912,11 +912,11 @@ $(document).ready(function () {
   // init search bar
 
   var noResultsYet = function (q) {
-    return /*$(*/ [
+    return /*$(*/[
       '<ul class="showAllResults loading">',
       '<li><a href="/search?q=' +
-        encodeURIComponent(q) +
-        '" target="_blank">Show all results...</a></li>',
+      encodeURIComponent(q) +
+      '" target="_blank">Show all results...</a></li>',
       '</ul>',
     ].join('\n') /*).ajaxify()[0]*/;
   };
@@ -950,13 +950,13 @@ $(document).ready(function () {
           return !tracks.length
             ? resultsHtml || ''
             : (resultsHtml || '</ul>').replace(
-                '</ul>',
-                '</ul>' +
-                  "<ul class='resultCategory'>" +
-                  '<div>Tracks</div>' +
-                  tracks.map(renderTrack).join('\n') +
-                  '</ul>'
-              );
+              '</ul>',
+              '</ul>' +
+              "<ul class='resultCategory'>" +
+              '<div>Tracks</div>' +
+              tracks.map(renderTrack).join('\n') +
+              '</ul>'
+            );
         }
         if (/^https?:\/\//.test(query))
           whydPlayer.fetchTrackByUrl(query, function (track) {
@@ -967,10 +967,10 @@ $(document).ready(function () {
               track.eId
                 ? prependExternalTracks([track])
                 : '<div class="noResults">' +
-                    "<p>Sorry, we don't recognize this URL...</p>" +
-                    '<p>We currently support URLs from Youtube, Soundcloud and Vimeo.</p>' +
-                    '<p>Please install and try <a href="/button">our "Add Track" button</a> from that page.</p>' +
-                    '</div>',
+                "<p>Sorry, we don't recognize this URL...</p>" +
+                '<p>We currently support URLs from Youtube, Soundcloud and Vimeo.</p>' +
+                '<p>Please install and try <a href="/button">our "Add Track" button</a> from that page.</p>' +
+                '</div>',
               false
             );
             // TODO: send this URL back to whyd/playemJS team
@@ -1165,12 +1165,12 @@ $(document).ready(function () {
           $menuChildren.filter(activeSelector).removeClass(activeClass);
           $menuChildren = $menuChildren.has(
             'a[href^="' +
-              relativeUrl +
-              '"],a[href^="/' +
-              relativeUrl +
-              '"],a[href^="' +
-              url +
-              '"]'
+            relativeUrl +
+            '"],a[href^="/' +
+            relativeUrl +
+            '"],a[href^="' +
+            url +
+            '"]'
           );
           if ($menuChildren.length === 1) {
             $menuChildren.addClass(activeClass);
@@ -1328,16 +1328,21 @@ window.sortPlaylists = function (sortType) {
   const allPlaylists = playlistsContainer.querySelectorAll('.playlist');
   let playlistsFragment = document.createDocumentFragment();
   let allPlaylistsObject = {};
+  let sortedPlaylistObjectKeys = [];
 
   if (allPlaylists.length > 2) {
     allPlaylists.forEach((playlist, index) => {
       if (playlist.dataset.playlistname) {
+
+        //store playlist name in a variable and add index to create a unique key in allPlaylistsObject
+        const playlistNameKey = playlist.dataset.playlistname.toLowerCase() + index;
+
         if (!playlist.dataset.index) {
           playlist.setAttribute('data-index', index);
         }
 
         if (sortType === 'alphabetize') {
-          allPlaylistsObject[playlist.dataset.playlistname] = playlist;
+          allPlaylistsObject[playlistNameKey] = playlist;
         } else if (sortType === 'date') {
           allPlaylistsObject[playlist.dataset.index] = playlist;
         }
@@ -1348,8 +1353,18 @@ window.sortPlaylists = function (sortType) {
 
     playlistsContainer.innerHTML = '';
 
-    Object.keys(allPlaylistsObject)
-      .sort()
+    if (sortType === 'date') {
+      sortedPlaylistObjectKeys = Object.keys(allPlaylistsObject).sort(
+        //if sorting by date first convert index key string to a number with '+' then compare to sort in ascending order.
+        function (firstPlaylistIndex, secondPlaylistIndex) {
+          return (+firstPlaylistIndex) - (+secondPlaylistIndex);
+        }
+      );
+    } else {
+      sortedPlaylistObjectKeys = Object.keys(allPlaylistsObject).sort();
+    }
+
+    sortedPlaylistObjectKeys
       .forEach((playlist) =>
         playlistsFragment.appendChild(allPlaylistsObject[playlist])
       );


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #411 
## What does this PR do / solve?
Currently the sort playlist feature is using the index and paylistname data attributes to sort by date and alphabet. The issue is that I did not realize that the array sort function takes into consideration lower and upper case when sorting. 

Also the index is being sorted as a string rather than a number which causes the playlist to be in the incorrect order when sorting by date.

## Overview of changes
The sort function will now lower case all playlist titles and convert index strings into numbers before sorting to prevent these bugs.

## How to test this PR?

If you currently sort the playlist with a user who has more than 10 playlists https://openwhyd.org/adrien/playlists the inspector shows an unexpected sort behavior.

After this update the sort by date will sort the playlist by the `data-index` attribute by ascending order:
![Screenshot from 2020-11-29 08-30-47](https://user-images.githubusercontent.com/13477167/100548186-e8709780-321f-11eb-8d77-ae2798c2e9be.png)

When using the alphabetize sort option the playlist will now correctly get ordered using the `data-playlistname` as expected regardless if the title is capitalized:
![Screenshot from 2020-11-29 08-31-17](https://user-images.githubusercontent.com/13477167/100548276-5f0d9500-3220-11eb-8f68-f56e2d48ad48.png)

