### PR TITLE
fix(tests): Clean up the database between each API test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "start": "node app.js --fakeEmail --digestInterval -1 $@",
     "start:coverage": "npx nyc --silent node app.js --fakeEmail --digestInterval -1 $@",
     "test-reset": "node test/reset-test-db.js",
-    "test-api": "npm run test-reset && npx mocha test/api/*.js --exit",
+    "test-api": "npx mocha test/api/*.js --serial --exit",
     "test-unit": "npx mocha test/unit/*.js --exit",
     "test:cypress:dev": "node_modules/.bin/cypress open",
     "test:cypress": "node_modules/.bin/cypress run",

--- a/test/api/auth.api.tests.js
+++ b/test/api/auth.api.tests.js
@@ -28,7 +28,7 @@ describe('auth api', () => {
     it('succeeds', async () => {
       const { response, body } = await loginAs(ADMIN_USER);
       const cookies = ((response.headers || {})['set-cookie'] || []).join(' ');
-      assert(/whydSid\=/.test(cookies));
+      assert(/whydSid=/.test(cookies));
       assert(body.redirect);
     });
 

--- a/test/api/auth.api.tests.js
+++ b/test/api/auth.api.tests.js
@@ -1,9 +1,9 @@
-/* global describe, it */
+/* global describe, it, before */
 
 var { promisify } = require('util');
 var assert = require('assert');
 
-var { ADMIN_USER, TEST_USER } = require('../fixtures.js');
+var { ADMIN_USER, TEST_USER, cleanup } = require('../fixtures.js');
 const apiClient = require('../api-client.js');
 
 const get = promisify(apiClient.get);
@@ -20,6 +20,8 @@ const genSecureUser = (() => {
     password: `mySecurePassword${number}`,
   });
 })();
+
+before(cleanup);
 
 describe('auth api', () => {
   describe('login with email', () => {

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -2,7 +2,7 @@
 
 var assert = require('assert');
 
-var { TEST_USER, cleanup } = require('../fixtures.js');
+var { ADMIN_USER, cleanup } = require('../fixtures.js');
 var api = require('../api-client.js');
 
 describe(`post api`, function () {
@@ -15,7 +15,7 @@ describe(`post api`, function () {
   };
 
   it(`should allow adding a track`, function (done) {
-    api.loginAs(TEST_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
       api.addPost(jar, post, function (error, { response, body }) {
         assert.ifError(error);
         assert.equal(body.eId, post.eId);
@@ -29,7 +29,7 @@ describe(`post api`, function () {
   });
 
   it(`should allow re-adding a track (aka "repost")`, function (done) {
-    api.loginAs(TEST_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
       api.addPost(jar, { pId }, function (error, { response, body }) {
         assert.ifError(error);
         assert(body._id);
@@ -52,7 +52,7 @@ describe(`post api`, function () {
   });
 
   it(`should allow adding a track to a playlist`, function (done) {
-    api.loginAs(TEST_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
       api.addPost(jar, postInPlaylist, function (error, { response, body }) {
         assert.ifError(error);
         assert(body._id);
@@ -66,7 +66,7 @@ describe(`post api`, function () {
   });
 
   it(`make sure that the playlist was created`, function (done) {
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       api.getUser(jar, {}, function (error, { response, body }) {
         assert.equal(body.pl.length, 1);
         assert.equal(body.pl[0].id, firstPlaylistIndex);
@@ -79,7 +79,7 @@ describe(`post api`, function () {
   });
 
   it(`should find 1 track in the playlist`, function (done) {
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       api.getPlaylist(jar, playlistFullId, function (
         error,
         { response, body }
@@ -95,7 +95,7 @@ describe(`post api`, function () {
   });
 
   it(`should return 1 track in the playlist`, function (done) {
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       api.getPlaylistTracks(jar, `u/${uId}`, firstPlaylistIndex, function (
         error,
         { response, body }
@@ -109,7 +109,7 @@ describe(`post api`, function () {
   });
 
   it(`should return 1 track in the playlist, with limit=1000`, function (done) {
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000`;
       api.get(jar, url, function (error, { response, body }) {
         assert.equal(body.length, 1);
@@ -121,7 +121,7 @@ describe(`post api`, function () {
   });
 
   it(`should return tracks if two limit parameters are provided`, function (done) {
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000&limit=20`;
       // => the `limit` property will be parsed as ["1000","20"] => causing bug #89
       api.get(jar, url, function (error, { response, body }) {
@@ -135,7 +135,7 @@ describe(`post api`, function () {
   // TODO: delete post
 
   it(`should return the comment data after adding it`, function (done) {
-    api.loginAs(TEST_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
       const comment = {
         pId,
         text: 'hello world',

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -1,11 +1,13 @@
-/* global describe, it */
+/* global describe, it, before */
 
 var assert = require('assert');
 
-var { TEST_USER } = require('../fixtures.js');
+var { TEST_USER, cleanup } = require('../fixtures.js');
 var api = require('../api-client.js');
 
 describe(`post api`, function () {
+  before(cleanup); // to prevent side effects between tests
+
   var pId, uId;
   const post = {
     eId: '/yt/XdJVWSqb4Ck',

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -15,8 +15,8 @@ describe(`post api`, function () {
   };
 
   it(`should allow adding a track`, function (done) {
-    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
-      api.addPost(jar, post, function (error, { response, body }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
+      api.addPost(jar, post, function (error, { body }) {
         assert.ifError(error);
         assert.equal(body.eId, post.eId);
         assert.equal(body.name, post.name);
@@ -29,8 +29,8 @@ describe(`post api`, function () {
   });
 
   it(`should allow re-adding a track (aka "repost")`, function (done) {
-    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
-      api.addPost(jar, { pId }, function (error, { response, body }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
+      api.addPost(jar, { pId }, function (error, { body }) {
         assert.ifError(error);
         assert(body._id);
         assert.notEqual(body._id, pId);
@@ -52,8 +52,8 @@ describe(`post api`, function () {
   });
 
   it(`should allow adding a track to a playlist`, function (done) {
-    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
-      api.addPost(jar, postInPlaylist, function (error, { response, body }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
+      api.addPost(jar, postInPlaylist, function (error, { body }) {
         assert.ifError(error);
         assert(body._id);
         assert.equal(body.eId, postInPlaylist.eId);
@@ -67,7 +67,7 @@ describe(`post api`, function () {
 
   it(`make sure that the playlist was created`, function (done) {
     api.loginAs(ADMIN_USER, function (error, { jar }) {
-      api.getUser(jar, {}, function (error, { response, body }) {
+      api.getUser(jar, {}, function (error, { body }) {
         assert.equal(body.pl.length, 1);
         assert.equal(body.pl[0].id, firstPlaylistIndex);
         assert.equal(body.pl[0].name, postInPlaylist.pl.name);
@@ -80,10 +80,7 @@ describe(`post api`, function () {
 
   it(`should find 1 track in the playlist`, function (done) {
     api.loginAs(ADMIN_USER, function (error, { jar }) {
-      api.getPlaylist(jar, playlistFullId, function (
-        error,
-        { response, body }
-      ) {
+      api.getPlaylist(jar, playlistFullId, function (error, { body }) {
         assert.ifError(error);
         assert.equal(body.length, 1);
         assert.equal(body[0].id, playlistFullId);
@@ -98,7 +95,7 @@ describe(`post api`, function () {
     api.loginAs(ADMIN_USER, function (error, { jar }) {
       api.getPlaylistTracks(jar, `u/${uId}`, firstPlaylistIndex, function (
         error,
-        { response, body }
+        { body }
       ) {
         assert.equal(body.length, 1);
         assert.equal(body[0].pl.id, firstPlaylistIndex);
@@ -111,7 +108,7 @@ describe(`post api`, function () {
   it(`should return 1 track in the playlist, with limit=1000`, function (done) {
     api.loginAs(ADMIN_USER, function (error, { jar }) {
       const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000`;
-      api.get(jar, url, function (error, { response, body }) {
+      api.get(jar, url, function (error, { body }) {
         assert.equal(body.length, 1);
         assert.equal(body[0].pl.id, firstPlaylistIndex);
         assert.equal(body[0].pl.name, postInPlaylist.pl.name);
@@ -124,7 +121,7 @@ describe(`post api`, function () {
     api.loginAs(ADMIN_USER, function (error, { jar }) {
       const url = `/u/${uId}/playlist/${firstPlaylistIndex}?format=json&limit=1000&limit=20`;
       // => the `limit` property will be parsed as ["1000","20"] => causing bug #89
-      api.get(jar, url, function (error, { response, body }) {
+      api.get(jar, url, function (error, { body }) {
         assert.notEqual(body.length, 0);
         done();
       });
@@ -135,12 +132,12 @@ describe(`post api`, function () {
   // TODO: delete post
 
   it(`should return the comment data after adding it`, function (done) {
-    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       const comment = {
         pId,
         text: 'hello world',
       };
-      api.addComment(jar, comment, function (error, { response, body }) {
+      api.addComment(jar, comment, function (error, { body }) {
         assert.ifError(error);
         assert.equal(body.pId, comment.pId);
         assert.equal(body.text, comment.text);

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -1,11 +1,12 @@
-/* global describe, it */
+/* global describe, it, before */
 
 var assert = require('assert');
-
-var { TEST_USER } = require('../fixtures.js');
+var { TEST_USER, cleanup } = require('../fixtures.js');
 var api = require('../api-client.js');
 
 describe(`user api -- getting user data`, function () {
+  before(cleanup); // to prevent side effects between tests
+
   it(`gets user profile data`, function (done) {
     const url =
       '/api/user?includeSubscr=true&isSubscr=true&countPosts=true&countLikes=true&getVersion=1';
@@ -23,6 +24,8 @@ describe(`user api -- getting user data`, function () {
 });
 
 describe(`user api -- setting user data`, function () {
+  before(cleanup); // to prevent side effects between tests
+
   it(`updates the user's name`, function (done) {
     api.loginAs(TEST_USER, function (error, { response, body, jar }) {
       assert.ifError(body.error);

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -27,16 +27,13 @@ describe(`user api -- setting user data`, function () {
   before(cleanup); // to prevent side effects between tests
 
   it(`updates the user's name`, function (done) {
-    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { body, jar }) {
       assert.ifError(body.error);
       assert(body.redirect);
-      api.getUser(jar, {}, function (error, { response, body }) {
+      api.getUser(jar, {}, function (error, { body }) {
         assert.equal(body.name, ADMIN_USER.name);
         const newName = 'renamed user';
-        api.setUser(jar, { name: newName }, function (
-          error,
-          { response, body }
-        ) {
+        api.setUser(jar, { name: newName }, function (error, { body }) {
           assert.equal(body.name, newName);
           done();
         });

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -1,7 +1,7 @@
 /* global describe, it, before */
 
 var assert = require('assert');
-var { TEST_USER, cleanup } = require('../fixtures.js');
+var { ADMIN_USER, cleanup } = require('../fixtures.js');
 var api = require('../api-client.js');
 
 describe(`user api -- getting user data`, function () {
@@ -10,12 +10,12 @@ describe(`user api -- getting user data`, function () {
   it(`gets user profile data`, function (done) {
     const url =
       '/api/user?includeSubscr=true&isSubscr=true&countPosts=true&countLikes=true&getVersion=1';
-    api.loginAs(TEST_USER, function (error, { jar }) {
+    api.loginAs(ADMIN_USER, function (error, { jar }) {
       api.get(jar, url, function (err, { body, ...res }) {
         assert.ifError(err);
         assert.equal(res.response.statusCode, 200);
         assert(!body.error);
-        assert.equal(body.email, TEST_USER.email);
+        assert.equal(body.email, ADMIN_USER.email);
         assert(body.openwhydServerVersion);
         done();
       });
@@ -27,11 +27,11 @@ describe(`user api -- setting user data`, function () {
   before(cleanup); // to prevent side effects between tests
 
   it(`updates the user's name`, function (done) {
-    api.loginAs(TEST_USER, function (error, { response, body, jar }) {
+    api.loginAs(ADMIN_USER, function (error, { response, body, jar }) {
       assert.ifError(body.error);
       assert(body.redirect);
       api.getUser(jar, {}, function (error, { response, body }) {
-        assert.equal(body.name, TEST_USER.name);
+        assert.equal(body.name, ADMIN_USER.name);
         const newName = 'renamed user';
         api.setUser(jar, { name: newName }, function (
           error,

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1,3 +1,5 @@
+const childProcess = require('child_process');
+
 exports.URL_PREFIX = 'http://localhost:8080';
 
 exports.ADMIN_USER = {
@@ -17,4 +19,11 @@ exports.TEST_USER = {
   pwd: 'test-user',
   password: 'test-user', // for the /register api endpoint
   md5: '42b27efc1480b4fe6d7eaa5eec47424d',
+};
+
+// Call this before each test to prevent side effects between tests
+exports.cleanup = (done) => {
+  console.warn('🧹 Cleaning up test db...');
+  const process = childProcess.fork('test/reset-test-db.js');
+  process.on('close', () => done());
 };


### PR DESCRIPTION
## What does this PR do / solve?

`user.api.tests.js` fails if it is not run after `auth.api.tests.js`, because the former relies on the presence of a user that was added to the db by the latter.

Proof, after resetting the db between tests: https://github.com/openwhyd/openwhyd/pull/417/checks?check_run_id=1581677648#step:10:114

## Overview of changes

Reset the db between each test suite, to prevent side effects.
