### PR TITLE
fix(email): Use API key for Sendgrid auth

### DIFF
--- a/app/models/emailSendgrid.js
+++ b/app/models/emailSendgrid.js
@@ -1,27 +1,13 @@
 /**
- * sendgrid email implementation (used by email.js generic wrapper)
- * send emails through sendgrid api
- * @author adrienjoly, whyd
+ * Sendgrid email implementation (used by email.js generic wrapper)
+ * to send emails through Sendgrid API.
  **/
 
 var https = require('https');
 var snip = require('./../snip.js');
-//var email = require("emailjs/email");
-
 var querystring = require('querystring');
 
-/*
-var credentials = {
-	user: "19aeb83d63953065a4939ce47fd6341d",
-	password: "d7d0d040efe01bb32ffcf10dd22d427c",
-	host: "in.mailjet.com",
-	tls: true,
-	domain: "mailjet.com"
-};
-console.log ("Email notifier connecting to SMTP server: ", credentials.host);
-
-var server = email.server.connect(credentials);
-*/
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY.substr();
 
 exports.email = function (
   emailAddr,
@@ -31,29 +17,15 @@ exports.email = function (
   userName,
   callback
 ) {
-  console.log('email', snip.formatEmail(emailAddr), subject);
-  /*
-	var message = email.message.create({
-		text: textContent, 
-		from: "openwhyd <contact@openwhyd.org>",
-		to: emailAddr,
-		subject: subject
-	});
-	
-	if (htmlContent) message.attach_alternative(htmlContent);
-	
-	server.send(message, function(err, message) {console.log("email callback: ", err || message);});
-	*/
+  console.log('[EMAIL] about to send:', snip.formatEmail(emailAddr), subject);
 
   if (!emailAddr)
     return callback && callback({ error: 'no email address was provided' });
 
   // Set up message
   var content = {
-    api_user: process.env.SENDGRID_API_USER.substr(), // "contact@openwhyd.org",
-    api_key: process.env.SENDGRID_API_KEY.substr(),
-    from: process.env.SENDGRID_API_FROM_EMAIL.substr(), // "no-reply@whyd.org",
-    fromname: process.env.SENDGRID_API_FROM_NAME.substr(), // "whyd",
+    from: process.env.SENDGRID_API_FROM_EMAIL.substr(), // e.g. "no-reply@whyd.org",
+    fromname: process.env.SENDGRID_API_FROM_NAME.substr(), // e.g. "whyd",
     to: emailAddr,
     subject: subject,
     text: textContent,
@@ -73,6 +45,7 @@ exports.email = function (
         port: 443,
         path: '/api/mail.send.json',
         headers: {
+          Authorization: `Bearer ${SENDGRID_API_KEY}`,
           'Content-Type': 'application/x-www-form-urlencoded',
           'Content-length': content.length,
         },
@@ -83,14 +56,14 @@ exports.email = function (
           data += chunk;
         });
         response.on('end', function () {
-          console.log('email response: ', data);
+          console.log('[EMAIL] response:', data);
           if (callback) callback(data);
         });
       }
     )
     .on('error', function (err) {
-      console.log('[ERR] emailSendgrid.email ', err);
-      console.error('[ERR] emailSendgrid.email ', err);
+      console.log('[EMAIL] send error:', err);
+      console.error('[EMAIL] send error:', err);
       if (callback) callback({ error: err });
     });
 


### PR DESCRIPTION
Cf [Upgrade your authentication method to API keys | SendGrid Documentation](https://sendgrid.com/docs/for-developers/sending-email/upgrade-your-authentication-method-to-api-keys/#upgrade-to-api-keys-for-your-smtp-integration)