### PR TITLE
fix(UI): allow selection of previously blocked items in search results div

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -558,6 +558,7 @@ input.search-input:focus {
   box-shadow: 0 0 3px rgba(0, 0, 0, 0.6);
   border-radius: 3px;
   background-clip: padding-box;
+  z-index: 1;
 }
 
 #searchResults ul {


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #434 .

## What does this PR do / solve?
Adds a z-index to the `searchResults` div, to allow selecting of the previously blocked item.
<!--
| Type a high-level summary.
|
| * Explain Why and How you're proposing these changes.
| * Explain anything non trivial that you're doing.
| * Anticipate the reviewer's question to save time.
| * Don't forget to provide context to reviewers.
-->

## Overview of changes

<!--
| If your PR introduces visual changes, add a screenshot.
| If your PR produces some output, add a screenshot/sample.
| If your PR fixes something, add a before/after sample/screenshot.
-->

## How to test this PR?
I tested this in the browser, just adding a z-index of 1 in `common.css`
<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
