### PR TITLE
fix(ci): Revert Applitools configuration for GitHub integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,16 +99,13 @@ jobs:
       - name: Run Cypress tests
         uses: cypress-io/github-action@v2.7.2
         with:
+          start: source env-vars-testing.sh
           config-file: cypress.json
           record: true
           parallel: true
         env:
           CI: true
-          # env vars for visual tests (driven by Cypress)
           APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
-          APPLITOOLS_BATCH_ID: ${{ github.sha }}
-          CYPRESS_APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
-          CYPRESS_APPLITOOLS_BATCH_ID: ${{ github.sha }}
           # pass the Dashboard record key as an environment variable
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_DASHBOARD_KEY }}
           # Recommended: pass the GitHub token lets this action correctly

--- a/applitools.config.js
+++ b/applitools.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  apiKey: process.env.APPLITOOLS_API_KEY,
-  batchId: process.env.APPLITOOLS_BATCH_ID,
-};
-
-console.log('applitools', module.exports);


### PR DESCRIPTION
This reverts changes from PR #432, because the error happened again after merging to master.

I also disabled github integration from Applitools' admin.
