### PR TITLE
fix(bookmarklet): "Identifier 'globals' has already been declared" when adding a track

### DIFF
--- a/cypress/integration/bookmarklet.spec.ts
+++ b/cypress/integration/bookmarklet.spec.ts
@@ -18,6 +18,7 @@ context('Openwhyd bookmarklet', () => {
       'window.jQuery', // Deezer failing to find window.jQuery
       `Cannot read property 'style' of null`, // TODO: fix this error
       'YOUTUBE_API_KEY is not defined', // TODO: fix this error
+      'The request cannot be completed because you have exceeded your <a href="/youtube/v3/getting-started#quota">quota', // Note: this error was witnessed in CI
     ];
     Cypress.on('uncaught:exception', (err) => {
       if (skippedErrors.some((errMsg) => err.message.includes(errMsg))) {

--- a/cypress/integration/bookmarklet.spec.ts
+++ b/cypress/integration/bookmarklet.spec.ts
@@ -12,11 +12,19 @@ context('Openwhyd bookmarklet', () => {
   };
 
   beforeEach('login', () => {
-    Cypress.on('uncaught:exception', () => {
-      // We prevent the following uncaught exceptions from failing the test:
-      // - YouTube failing to load "/cast/sdk/libs/sender/1.0/cast_framework.js"
-      // - Deezer failing to find window.jQuery
-      return false; // prevents Cypress from failing the test
+    // We prevent the following uncaught exceptions from failing the test:
+    const skippedErrors = [
+      'cast_framework.js', // YouTube failing to load "/cast/sdk/libs/sender/1.0/cast_framework.js"
+      'window.jQuery', // Deezer failing to find window.jQuery
+      `Cannot read property 'style' of null`, // TODO: fix this error
+      'YOUTUBE_API_KEY is not defined', // TODO: fix this error
+    ];
+    Cypress.on('uncaught:exception', (err) => {
+      if (skippedErrors.some((errMsg) => err.message.includes(errMsg))) {
+        return false; // prevents Cypress from failing the test
+      } else {
+        return true;
+      }
     });
 
     cy.fixture('users.js').then(({ dummy }) => {

--- a/public/js/postBoxV2.js
+++ b/public/js/postBoxV2.js
@@ -1,6 +1,6 @@
 /* global $ */
 
-const globals = window;
+window.globals = window;
 
 /**
  * post box for openwhyd music


### PR DESCRIPTION
Contributes to #439, at least for YouTube tracks.

The bug is probably caused by https://github.com/openwhyd/openwhyd/pull/429/files#diff-d0670720fd54d514c34d0215269319d1cc83b4fcca7113085edd1040a262febcR3.

- [x] reproduce bug in CI (see https://github.com/openwhyd/openwhyd/pull/439/checks?check_run_id=1756869331#step:8:132)
- [x] fix bug
- [ ] address TODOs