### PR TITLE
fix(bandcamp): De-duplicate stream URLs from Bandcamp

### DIFF
--- a/app/controllers/api/bandcampExtractor.js
+++ b/app/controllers/api/bandcampExtractor.js
@@ -4,8 +4,10 @@ var config = require('../../models/config.js');
 const RE_EID = /^\/bc\/([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/;
 const RE_STREAM_URL = /https:\/\/[^.]+\.bcbits\.com\/stream\/[^;"]*/g;
 
+const dedup = (array) => [...new Set(array).keys()];
+
 exports.extractBandcampStreamURLs = (plainText) =>
-  plainText.match(RE_STREAM_URL);
+  dedup(plainText.match(RE_STREAM_URL));
 
 exports.extractBandcampStreamURLsFromHTML = (html) => {
   const withDecodedEntities = htmlDecode(html);

--- a/test/unit/unit-tests.js
+++ b/test/unit/unit-tests.js
@@ -122,7 +122,7 @@ describe('"img" package', function () {
     try {
       fs.unlinkSync(thumbOutput);
     } catch (e) {
-      console.error(e);
+      console.error(e.message);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
See https://github.com/openwhyd/openwhyd/pull/443/checks?check_run_id=1849601856#step:9:109:

```
  1) bandcampExtractor
       should extract the stream URL from an actual track page:

      AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:

2 !== 1

      + expected - actual

      -2
      +1
      
      at Context.<anonymous> (test/unit/bandcampExtractor-tests.js:35:12)
```
