### PR TITLE
fix(fb): Update Facebook login SDK

### DIFF
--- a/app/models/facebook.js
+++ b/app/models/facebook.js
@@ -32,7 +32,7 @@ exports.graphApiRequest = function (fbAccessToken, path, params, handler) {
   params.access_token = fbAccessToken;
   params.metadata = !!params.metadata;
   params.method = params.method || 'GET';
-  var url = '/v2.3' + path + '?' + querystring.stringify(params);
+  var url = path + '?' + querystring.stringify(params);
   https
     .request(
       { path: url, host: host, port: 443, method: params.method },

--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -2,8 +2,8 @@ var vm = require('vm');
 var async = require('async');
 var mongodb = require('mongodb');
 
-const PRINT_ACTIVE = true;
-const VERBOSE = true; // true to display debug logs (for diagnostics and testing)
+const PRINT_ACTIVE = false;
+const VERBOSE = false; // true to display debug logs (for diagnostics and testing)
 const LOG_PREFIX = '[mongo shell]';
 
 function buildContext(db, nextCommand, callback) {
@@ -101,7 +101,6 @@ exports.runScriptOnDatabase = function (script, db, callback) {
         .replace(/[\r\n]+/g, '') // remove line breaks, so that multiple lines of comments == ""
         .replace(/\/\*.*\*\//g, '') // remove /**/ comments
         .trim();
-      console.log('CLEANED', `[${cleaned}]`);
       if (!cleaned) {
         VERBOSE && console.log(LOG_PREFIX, 'IGN', command);
         nextCommand();

--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -94,8 +94,15 @@ exports.runScriptOnDatabase = function (script, db, callback) {
   async.eachSeries(
     commands,
     function (command, nextCommand) {
-      command = command.trim();
-      if (!command || /^\/\//.test(command) || /^\/\*.*\*\/$/.test(command)) {
+      const cleaned = command
+        .split(/[\r\n]+/g) // split lines
+        .map((line) => line.replace(/\/\/.*/, '')) // remove // comments
+        .join(' ') // join lines as one
+        .replace(/[\r\n]+/g, '') // remove line breaks, so that multiple lines of comments == ""
+        .replace(/\/\*.*\*\//g, '') // remove /**/ comments
+        .trim();
+      console.log('CLEANED', `[${cleaned}]`);
+      if (!cleaned) {
         VERBOSE && console.log(LOG_PREFIX, 'IGN', command);
         nextCommand();
       } else {

--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -2,8 +2,8 @@ var vm = require('vm');
 var async = require('async');
 var mongodb = require('mongodb');
 
-const PRINT_ACTIVE = false;
-const VERBOSE = false; // true to display debug logs (for diagnostics and testing)
+const PRINT_ACTIVE = true;
+const VERBOSE = true; // true to display debug logs (for diagnostics and testing)
 const LOG_PREFIX = '[mongo shell]';
 
 function buildContext(db, nextCommand, callback) {

--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -202,8 +202,8 @@ exports.initCollections = function ({ addTestData } = {}) {
       function (initScript, nextScript) {
         console.log('[db] Applying db init script:', initScript, '...');
         exports.runShellScript(fs.readFileSync(initScript), function (err) {
-          if (err) throw err;
-          nextScript();
+          if (err) console.error(err);
+          nextScript(err);
         });
       },
       function (err) {

--- a/app/templates/mainTemplate.js
+++ b/app/templates/mainTemplate.js
@@ -20,11 +20,6 @@ if (isProduction) {
   //console.log('- Production - ');
   fbId = '169250156435902';
   playemFile = 'min';
-} else if (config.urlPrefix.indexOf('whyd.fr') > 0) {
-  // pre-production
-  //console.log('- Test - ');
-  fbId = '1059973490696893';
-  playemFile = 'all';
 } else {
   //console.log('- Local - ');
   fbId = '118010211606360';

--- a/app/templates/mainTemplate.js
+++ b/app/templates/mainTemplate.js
@@ -22,7 +22,7 @@ if (isProduction) {
   playemFile = 'min';
 } else {
   //console.log('- Local - ');
-  fbId = '118010211606360';
+  fbId = '1573219269412628';
   playemFile = 'all';
 }
 

--- a/config/initdb_testing.js
+++ b/config/initdb_testing.js
@@ -1,3 +1,5 @@
+/* globals db, ObjectId */
+
 // Usage: this file should be run by runShellScript() or by mongo's CLI:
 // $ mongo openwhyd_data initdb_testing.js
 

--- a/cypress/fixtures/users.js
+++ b/cypress/fixtures/users.js
@@ -1,4 +1,5 @@
 ({
+  // TODO: make sure that this data remains in sync with what's add in the db, in initdb_testing.js
   admin: {
     id: '000000000000000000000001',
     email: process.env.WHYD_ADMIN_EMAIL || 'test@openwhyd.org',

--- a/public/html/testFbInvite.html
+++ b/public/html/testFbInvite.html
@@ -37,7 +37,7 @@
         // pre-production
         fbId = '1059973490696893';
       } else {
-        fbId = '118010211606360';
+        fbId = '118010211606360'; // note: this "openwhyd-dev" app was deleted on 14/05/2021, in favor of test app id 1573219269412628
       }
 
       window.user = { id: '4d94501d1f78ac091dbc9b4d', name: 'Adrien Joly' };

--- a/public/js/facebook.js
+++ b/public/js/facebook.js
@@ -8,11 +8,7 @@ var fbId;
 if (href.indexOf('openwhyd.org/') > 0) {
   // namespace = 'whydapp';
   fbId = '169250156435902';
-} /*else if (href.indexOf('whyd.fr/') > 0) {
-  // pre-production
-  namespace = 'whyd-test';
-  fbId = '1059973490696893';
-} */ else {
+} else {
   // namespace = 'whyd-dev';
   fbId = '118010211606360';
 }

--- a/public/js/facebook.js
+++ b/public/js/facebook.js
@@ -10,7 +10,7 @@ if (href.indexOf('openwhyd.org/') > 0) {
   fbId = '169250156435902';
 } else {
   // namespace = 'whyd-dev';
-  fbId = '118010211606360';
+  fbId = '1573219269412628';
 }
 
 var facebookPerms = 'public_profile,email';
@@ -143,10 +143,8 @@ globals.fbRegister = function (perms, cb) {
 globals.fbAsyncInit = function () {
   globals.FB.init({
     appId: fbId,
-    version: 'v2.3',
-    status: true,
+    version: 'v10.0',
     cookie: true,
-    oauth: true,
     xfbml: true,
   });
   globals.whenFbReady = function (fct) {
@@ -168,17 +166,14 @@ globals.whenFbReady(function () {
 });
 
 // Load the SDK Asynchronously
-(function (d) {
-  /*if (!d.getElementById("fb-root"))
-		d.getElementsByTagName('body')[0].appendChild(d.createElement('div')).id = "fb-root";*/
+(function (d, s, id) {
   var js,
-    id = 'facebook-jssdk';
+    fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) {
     return;
   }
-  js = d.createElement('script');
+  js = d.createElement(s);
   js.id = id;
-  js.async = true;
-  js.src = '//connect.facebook.net/en_US/sdk.js';
-  d.getElementsByTagName('head')[0].appendChild(js);
-})(document);
+  js.src = 'https://connect.facebook.net/en_US/sdk.js';
+  fjs.parentNode.insertBefore(js, fjs);
+})(document, 'script', 'facebook-jssdk');


### PR DESCRIPTION
Addresses:

- "Your Facebook SDK is out-of-date. Please upgrade to v5.0 for access to new privacy features." banner from https://developers.facebook.com/apps/169250156435902/dashboard/
- "App Inactive for More Than 90 Days" banner from https://developers.facebook.com/apps/118010211606360/dashboard/ and https://developers.facebook.com/apps/1059973490696893/dashboard/ (old *development* fb apps)

May also contribute to #370.

Refs:

- [Working with Facebook login from localhost - Stack Overflow](https://stackoverflow.com/questions/39800216/working-with-facebook-login-from-localhost/57607570#57607570)
- [Using the Graph API](https://developers.facebook.com/docs/graph-api/using-graph-api/)
- [Graph API - Web SDKs](https://developers.facebook.com/docs/javascript/reference/FB.api)
- [Facebook Login - Quick start](https://developers.facebook.com/apps/1573219269412628/fb-login/quickstart/) for app `whyd - development`

Other considered refs:

- [How to Test Facebook Login? - Stack Overflow](https://stackoverflow.com/questions/31794428/how-to-test-facebook-login)
- [Testing - Facebook Login](https://developers.facebook.com/docs/facebook-login/testing-your-login-flow/)
- [Test Users - App Development](https://developers.facebook.com/docs/development/build-and-test/test-users/)
- [Best Practices | Cypress Documentation](https://docs.cypress.io/guides/references/best-practices#Visiting-external-sites)