### PR TITLE
fix(tests): extract getRaw(), to allow fetching HTML pages

### DIFF
--- a/test/api-client.js
+++ b/test/api-client.js
@@ -68,18 +68,24 @@ exports.signupAs = function signupAs(user, callback) {
 };
 // HTTP request wrappers
 
-exports.get = function (jar, url, callback) {
+exports.getRaw = function (jar, url, callback) {
   request.get(
     { jar, url: `${URL_PREFIX}${url}` },
     function (error, response, body) {
-      try {
-        body = JSON.parse(body);
-      } catch (e) {
-        console.error(e);
-      }
-      callback(error, { response, body, jar });
+      callback(error, { response, body });
     }
   );
+};
+
+exports.get = function (jar, url, callback) {
+  exports.getRaw(jar, url, function (error, { response, body }) {
+    try {
+      body = JSON.parse(body);
+    } catch (e) {
+      console.error(e);
+    }
+    callback(error, { response, body, jar });
+  });
 };
 
 // USER

--- a/test/api-client.js
+++ b/test/api-client.js
@@ -79,12 +79,13 @@ exports.getRaw = function (jar, url, callback) {
 
 exports.get = function (jar, url, callback) {
   exports.getRaw(jar, url, function (error, { response, body }) {
+    let parsedBody = undefined;
     try {
-      body = JSON.parse(body);
+      parsedBody = JSON.parse(body);
     } catch (e) {
-      console.error(e);
+      error = error | e;
     }
-    callback(error, { response, body, jar });
+    callback(error, { response, body: parsedBody, jar });
   });
 };
 


### PR DESCRIPTION
## Problem

In order to write approval tests on the features covered by `userLibrary.js`, it would be nice if the `api-client` helper provided a method to fetch HTML pages too.

## Proposed solution

- extract `getRaw()`, to allow fetching HTML pages
- make `get()` use `getRaw()`
- fix, while we're at it: in case of JSON parsing error, pass that error to the callback instead of printing it to console and returning the unparsed body