### PR TITLE
refactor(userProfile): Decouple rendering and data fetching from API parameters

### DIFF
--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -88,6 +88,10 @@ class FeedRenderingOptions {
       ...options,
     };
   }
+
+  shouldRenderWholePageLayout() {
+    return !this.options.after && !this.options.before;
+  }
 }
 
 /** @param {FeedRenderingOptions} renderingOptions */
@@ -100,7 +104,7 @@ function prepareFeedVars(posts, renderingOptions) {
     userPrefs: (options.loggedUser || {}).pref || {},
     loggedUser: options.loggedUser,
     isUserLogged: options.loggedUser && options.loggedUser.id,
-    header: !options.after && !options.before,
+    header: renderingOptions.shouldRenderWholePageLayout(),
     emptyFeed:
       posts.length == 0 && !options.before
         ? { ownProfile: options.ownProfile }

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -92,6 +92,10 @@ class FeedRenderingOptions {
   shouldRenderWholePageLayout() {
     return !this.options.after && !this.options.before;
   }
+
+  getPostsRenderingOptions() {
+    return this.options; // TODO: return just what is needed by renderPostsAsync()
+  }
 }
 
 /** @param {FeedRenderingOptions} renderingOptions */
@@ -207,9 +211,10 @@ function prepareFeedVars(posts, renderingOptions) {
 }
 
 exports.renderFeedAsync = function (posts, options, callback) {
-  postsTemplate.renderPostsAsync(posts, options, function (postsHtml) {
-    const feedRenderingOptions = new FeedRenderingOptions(options || {});
-    var feedVars = prepareFeedVars(posts, feedRenderingOptions);
+  const feedRenderOpts = new FeedRenderingOptions(options || {});
+  const postsRenderOpts = feedRenderOpts.getPostsRenderingOptions();
+  postsTemplate.renderPostsAsync(posts, postsRenderOpts, function (postsHtml) {
+    var feedVars = prepareFeedVars(posts, feedRenderOpts);
     feedVars.posts = postsHtml;
 
     //loadTemplates(function(){

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -55,7 +55,7 @@ loadTemplates();
 
 class FeedRenderingOptions {
   constructor(options) {
-    this.options = options;
+    this.options = { ...options };
   }
 }
 

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -55,15 +55,17 @@ loadTemplates();
 
 class FeedRenderingOptions {
   constructor(options) {
-    this.options = { ...options };
+    this.options = {
+      ...options,
+      bodyClass:
+        (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : ''),
+    };
   }
 }
 
 /** @param {FeedRenderingOptions} renderingOptions */
 function prepareFeedVars(posts, renderingOptions) {
   const options = renderingOptions.options;
-  options.bodyClass =
-    (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : '');
 
   var feedVars = {
     sideBox: templates['sideBox'].render(),

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -55,6 +55,35 @@ loadTemplates();
 
 class FeedRenderingOptions {
   constructor(options) {
+    /** @type {{
+     *    title: unknown,
+     *    user: { id: unknown, name: unknown, img: unknown, bio: unknown, renderedBio: unknown, nbTracks: unknown, nbPosts: unknown, nbLikes: unknown }
+     *    ownProfile: unknown
+     *    subscriptions: unknown
+     *    recentActivity: unknown
+     *    nbPosts: unknown
+     *    globalFeed: unknown
+     *    homeFeed: unknown
+     *    tabTitle: unknown
+     *    loggedUser: { pref: unknown, id: unknown }
+     *    before: unknown
+     *    hasMore: unknown
+     *    playlist: { name: unknown }
+     *    nextPageInList: unknown
+     *    prevPageInList: unknown
+     *    friends: unknown
+     *    activity: unknown
+     *    playlists: unknown
+     *    nbPlaylists: unknown
+     *    showTracks: unknown
+     *    showPlaylists: unknown
+     *    showLikes: unknown
+     *    showActivity: unknown
+     *    showSubscribers: unknown
+     *    showSubscriptions: unknown
+     *    similarity: unknown
+     *    embedW: unknown
+     *  }} */
     this.options = {
       ...options,
     };

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * userLibraryFeed template
  * renders a gallery/feed/timeline of posts, for a given user's category
@@ -51,7 +53,15 @@ async function loadTemplates() {
 
 loadTemplates();
 
-function prepareFeedVars(posts, options) {
+class FeedRenderingOptions {
+  constructor(options) {
+    this.options = options;
+  }
+}
+
+/** @param {FeedRenderingOptions} renderingOptions */
+function prepareFeedVars(posts, renderingOptions) {
+  const options = renderingOptions.options;
   options.bodyClass =
     (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : '');
 
@@ -165,7 +175,8 @@ function prepareFeedVars(posts, options) {
 
 exports.renderFeedAsync = function (posts, options, callback) {
   postsTemplate.renderPostsAsync(posts, options, function (postsHtml) {
-    var feedVars = prepareFeedVars(posts, options);
+    const feedRenderingOptions = new FeedRenderingOptions(options || {});
+    var feedVars = prepareFeedVars(posts, feedRenderingOptions);
     feedVars.posts = postsHtml;
 
     //loadTemplates(function(){

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -55,6 +55,11 @@ loadTemplates();
 
 class FeedRenderingOptions {
   constructor(options) {
+    const ownProfile =
+      options.user &&
+      options.user.id &&
+      options.user.id == options.loggedUser.id;
+
     /** @type {{
      *    title: unknown,
      *    user: { id: unknown, name: unknown, img: unknown, bio: unknown, renderedBio: unknown, nbTracks: unknown, nbPosts: unknown, nbLikes: unknown }
@@ -87,6 +92,8 @@ class FeedRenderingOptions {
      *  }} */
     this.options = {
       ...options,
+      ownProfile,
+      bodyClass: (options.bodyClass || '') + (ownProfile ? ' ownProfile' : ''),
     };
   }
 
@@ -95,11 +102,7 @@ class FeedRenderingOptions {
   }
 
   isOwnProfile() {
-    return (
-      this.options.user &&
-      this.options.user.id &&
-      this.options.user.id == this.options.loggedUser.id
-    );
+    return this.options.ownProfile;
   }
 
   getPostsRenderingOptions() {
@@ -107,9 +110,6 @@ class FeedRenderingOptions {
       // TODO: return just what is needed by renderPostsAsync()
       ...this.options,
       isOwnProfile: this.isOwnProfile.bind(this),
-      getBodyClass: () =>
-        (this.options.bodyClass || '') +
-        (this.isOwnProfile() ? ' ownProfile' : ''),
     };
   }
 }

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -63,7 +63,7 @@ class FeedRenderingOptions {
     /** @type {{
      *    title: unknown,
      *    user: { id: unknown, name: unknown, img: unknown, bio: unknown, renderedBio: unknown, nbTracks: unknown, nbPosts: unknown, nbLikes: unknown }
-     *    ownProfile: unknown
+     *    ownProfile: boolean
      *    subscriptions: unknown
      *    recentActivity: unknown
      *    nbPosts: unknown
@@ -103,14 +103,6 @@ class FeedRenderingOptions {
 
   isOwnProfile() {
     return this.options.ownProfile;
-  }
-
-  getPostsRenderingOptions() {
-    return {
-      // TODO: return just what is needed by renderPostsAsync()
-      ...this.options,
-      isOwnProfile: this.isOwnProfile.bind(this),
-    };
   }
 }
 
@@ -228,8 +220,7 @@ function prepareFeedVars(posts, renderingOptions) {
 
 exports.renderFeedAsync = function (posts, options, callback) {
   const feedRenderOpts = new FeedRenderingOptions(options || {});
-  const postsRenderOpts = feedRenderOpts.getPostsRenderingOptions();
-  postsTemplate.renderPostsAsync(posts, postsRenderOpts, function (postsHtml) {
+  postsTemplate.renderPostsAsync(posts, feedRenderOpts, function (postsHtml) {
     var feedVars = prepareFeedVars(posts, feedRenderOpts);
     feedVars.posts = postsHtml;
 

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -57,8 +57,6 @@ class FeedRenderingOptions {
   constructor(options) {
     this.options = {
       ...options,
-      bodyClass:
-        (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : ''),
     };
   }
 }

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -93,8 +93,20 @@ class FeedRenderingOptions {
     return !this.options.after && !this.options.before;
   }
 
+  isOwnProfile() {
+    return (
+      this.options.user &&
+      this.options.user.id &&
+      this.options.user.id == this.options.loggedUser.id
+    );
+  }
+
   getPostsRenderingOptions() {
-    return this.options; // TODO: return just what is needed by renderPostsAsync()
+    return {
+      // TODO: return just what is needed by renderPostsAsync()
+      ...this.options,
+      isOwnProfile: this.isOwnProfile.bind(this),
+    };
   }
 }
 
@@ -111,10 +123,10 @@ function prepareFeedVars(posts, renderingOptions) {
     header: renderingOptions.shouldRenderWholePageLayout(),
     emptyFeed:
       posts.length == 0 && !options.before
-        ? { ownProfile: options.ownProfile }
+        ? { ownProfile: renderingOptions.isOwnProfile() }
         : null,
     nbPosts: options.nbPosts || (options.user ? options.user.nbPosts : null),
-    ownProfile: options.ownProfile,
+    ownProfile: renderingOptions.isOwnProfile(),
     libRootUrl: '/stream',
     subscriptions: options.subscriptions, // = {nbSubscribers, nbSubscriptions}
     recentActivity: options.recentActivity,

--- a/app/templates/feed.js
+++ b/app/templates/feed.js
@@ -83,6 +83,7 @@ class FeedRenderingOptions {
      *    showSubscriptions: unknown
      *    similarity: unknown
      *    embedW: unknown
+     *    bodyClass: unknown
      *  }} */
     this.options = {
       ...options,
@@ -106,6 +107,9 @@ class FeedRenderingOptions {
       // TODO: return just what is needed by renderPostsAsync()
       ...this.options,
       isOwnProfile: this.isOwnProfile.bind(this),
+      getBodyClass: () =>
+        (this.options.bodyClass || '') +
+        (this.isOwnProfile() ? ' ownProfile' : ''),
     };
   }
 }

--- a/app/templates/posts.js
+++ b/app/templates/posts.js
@@ -253,20 +253,43 @@ exports.renderPosts = function (posts, options) {
   });
 };
 
+/*
+ *    title: unknown,
+ *    user: { id: unknown, name: unknown, img: unknown, bio: unknown, renderedBio: unknown, nbTracks: unknown, nbPosts: unknown, nbLikes: unknown }
+ *    ownProfile: unknown
+ *    subscriptions: unknown
+ *    recentActivity: unknown
+ *    nbPosts: unknown
+ *    globalFeed: unknown
+ *    homeFeed: unknown
+ *    tabTitle: unknown
+ *    before: unknown
+ *    hasMore: unknown
+ *    playlist: { name: unknown }
+ *    nextPageInList: unknown
+ *    prevPageInList: unknown
+ *    friends: unknown
+ *    activity: unknown
+ *    playlists: unknown
+ *    nbPlaylists: unknown
+ *    showTracks: unknown
+ *    showPlaylists: unknown
+ *    showLikes: unknown
+ *    showActivity: unknown
+ *    showSubscribers: unknown
+ *    showSubscriptions: unknown
+ *    similarity: unknown
+ *    embedW: unknown
+ *    loggedUser: { pref: unknown, id: unknown }
+ */
 
 /** @param {{
+ *    isOwnProfile: () => boolean
  * }} options */
 exports.renderPostsAsync = function (posts, options, callback) {
   posts = posts || [];
-  options.loggedUser =
-    options.loggedUser ||
-    {
-      /*id:-1*/
-    };
-  options.ownProfile =
-    options.user && options.user.id && options.user.id == options.loggedUser.id;
   options.bodyClass =
-    (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : '');
+    (options.bodyClass || '') + (options.isOwnProfile() ? ' ownProfile' : '');
 
   var maxPosts =
     options.limit || (options.embedW ? MAX_POSTS_EMBED : MAX_POSTS);
@@ -305,7 +328,7 @@ exports.renderPostsAsync = function (posts, options, callback) {
             customTemplateFile: options.customTemplateFile,
             customImgHandler: options.customImgHandler,
             templateVars: options.templateVars,
-            ownProfile: options.ownProfile,
+            ownProfile: options.isOwnProfile(),
             displayVia: !!options.embedW,
             displayPlaylistName: options.displayPlaylistName,
           },

--- a/app/templates/posts.js
+++ b/app/templates/posts.js
@@ -255,7 +255,6 @@ exports.renderPosts = function (posts, options) {
 
 /** @param {{
  *    isOwnProfile: () => boolean
- *    getBodyClass: () => string
  * }} options */
 exports.renderPostsAsync = function (posts, options, callback) {
   posts = posts || [];

--- a/app/templates/posts.js
+++ b/app/templates/posts.js
@@ -253,43 +253,12 @@ exports.renderPosts = function (posts, options) {
   });
 };
 
-/*
- *    title: unknown,
- *    user: { id: unknown, name: unknown, img: unknown, bio: unknown, renderedBio: unknown, nbTracks: unknown, nbPosts: unknown, nbLikes: unknown }
- *    ownProfile: unknown
- *    subscriptions: unknown
- *    recentActivity: unknown
- *    nbPosts: unknown
- *    globalFeed: unknown
- *    homeFeed: unknown
- *    tabTitle: unknown
- *    before: unknown
- *    hasMore: unknown
- *    playlist: { name: unknown }
- *    nextPageInList: unknown
- *    prevPageInList: unknown
- *    friends: unknown
- *    activity: unknown
- *    playlists: unknown
- *    nbPlaylists: unknown
- *    showTracks: unknown
- *    showPlaylists: unknown
- *    showLikes: unknown
- *    showActivity: unknown
- *    showSubscribers: unknown
- *    showSubscriptions: unknown
- *    similarity: unknown
- *    embedW: unknown
- *    loggedUser: { pref: unknown, id: unknown }
- */
-
 /** @param {{
  *    isOwnProfile: () => boolean
+ *    getBodyClass: () => string
  * }} options */
 exports.renderPostsAsync = function (posts, options, callback) {
   posts = posts || [];
-  options.bodyClass =
-    (options.bodyClass || '') + (options.isOwnProfile() ? ' ownProfile' : '');
 
   var maxPosts =
     options.limit || (options.embedW ? MAX_POSTS_EMBED : MAX_POSTS);

--- a/app/templates/posts.js
+++ b/app/templates/posts.js
@@ -261,6 +261,8 @@ exports.renderPostsAsync = function (posts, options, callback) {
     };
   options.ownProfile =
     options.user && options.user.id && options.user.id == options.loggedUser.id;
+  options.bodyClass =
+    (options.bodyClass || '') + (options.ownProfile ? ' ownProfile' : '');
 
   var maxPosts =
     options.limit || (options.embedW ? MAX_POSTS_EMBED : MAX_POSTS);

--- a/app/templates/posts.js
+++ b/app/templates/posts.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 /**
  * Html-based template for rendering a feed of posts
  * @author adrienjoly, whyd
@@ -251,9 +253,11 @@ exports.renderPosts = function (posts, options) {
   });
 };
 
+
+/** @param {{
+ * }} options */
 exports.renderPostsAsync = function (posts, options, callback) {
   posts = posts || [];
-  options = options || {};
   options.loggedUser =
     options.loggedUser ||
     {


### PR DESCRIPTION
Alternative to PR #476, #478 and #479. Follows investigation PR #480.

Strategy: decouple rendering and data fetching from API parameters by progressively encapsulating options into a typed class, starting by `feed.prepareFeedVars()`.

```
$ docker-compose up --build --detach web && \
  ./scripts/wait-for-http-server.sh 8080 && \
  WHYD_GENUINE_SIGNUP_SECRET="whatever" npx ava test/approval.tests.js
```