### PR TITLE
fix(semantic-release): Bump version after refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,17 +84,33 @@
   "release": {
     "branch": "master",
     "plugins": [
-      ["@semantic-release/commit-analyzer", {
-        "preset": "angular",
-        "releaseRules": [
-          {"type": "docs", "scope":"README", "release": "patch"},
-          {"type": "refactor", "release": "patch"},
-          {"type": "style", "release": "patch"}
-        ],
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
+      [
+        "@semantic-release/commit-analyzer",
+        {
+          "preset": "angular",
+          "releaseRules": [
+            {
+              "type": "docs",
+              "scope": "README",
+              "release": "patch"
+            },
+            {
+              "type": "refactor",
+              "release": "patch"
+            },
+            {
+              "type": "style",
+              "release": "patch"
+            }
+          ],
+          "parserOpts": {
+            "noteKeywords": [
+              "BREAKING CHANGE",
+              "BREAKING CHANGES"
+            ]
+          }
         }
-      }],
+      ],
       "@semantic-release/changelog",
       "@semantic-release/git",
       "@semantic-release/npm",


### PR DESCRIPTION
References:
- https://github.com/semantic-release/semantic-release/issues/472
- https://github.com/semantic-release/commit-analyzer#releaserules
- https://github.com/semantic-release/semantic-release/blob/master/docs/usage/configuration.md#plugins
- https://github.com/semantic-release/semantic-release/blob/master/docs/usage/plugins.md#plugins-declaration-and-execution-order
