### PR TITLE
fix(tests): Try to reduce Cypress flakiness by removing FB tracking

### DIFF
--- a/public/js/facebook.js
+++ b/public/js/facebook.js
@@ -153,18 +153,6 @@ globals.fbAsyncInit = function () {
   while (whenFbReadyQueue.length) whenFbReadyQueue.shift()();
 };
 
-globals.whenFbReady(function () {
-  console.log('watching fb events');
-  globals.FB.Event.subscribe('edge.create', function (targetUrl) {
-    globals.Whyd.tracking.logSocial('facebook', 'like', targetUrl);
-  });
-  globals.FB.Event.subscribe('message.send', function (sharedUrl) {
-    //var pId = sharedUrl.split("/").pop();
-    //console.log("facebook invitation was sent", pId);
-    globals.Whyd.tracking.logSocial('facebook', 'message', sharedUrl);
-  });
-});
-
 // Load the SDK Asynchronously
 (function (d, s, id) {
   var js,

--- a/public/js/whydtr.js
+++ b/public/js/whydtr.js
@@ -145,11 +145,6 @@ window.Whyd.tracking =
       this._log('event', action); // redundant event, just for the sequence diagram there: for https://www.google.com/analytics/web/#report/content-engagement-flow/a23759101w46480794p46730353/%3F_.useg%3Dbuiltin1%2Cbuiltin2%26_r.engageMode%3Devents%26_r.screen%3D%2F/
     };
 
-    this.logSocial = function (network, action, url) {
-      this.log('Social: ' + network + ' ' + action, url);
-      this._log('social', network, action, url);
-    };
-
     this.logTrackPlay = function (pId) {
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/events
       this.log('play', pId);


### PR DESCRIPTION
Cf: https://github.com/openwhyd/openwhyd/runs/4486211855?check_suite_focus=true#step:8:4554

![image](https://user-images.githubusercontent.com/531781/145612237-40942321-3396-49a0-8d44-f1b63715ab42.png)

![image](https://user-images.githubusercontent.com/531781/145612280-a8330750-5dd9-4295-a8a0-6d3a3d0f0f0a.png)

Hypothesis:

> The only events you can subscribe to now via the JS SDK are related to the auth status changing, and when social plugins embedded into a page have been rendered.

Source: https://stackoverflow.com/a/52051424/592254