### PR TITLE
fix(tests): Enforce Cypress timeouts despite retries

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -7,5 +7,12 @@
   "retries": {
     "runMode": 2,
     "openMode": 0
-  }
+  },
+  "defaultCommandTimeout": 4000,
+  "execTimeout": 60000,
+  "taskTimeout": 60000,
+  "pageLoadTimeout": 60000,
+  "requestTimeout": 5000,
+  "responseTimeout": 30000,
+  "slowTestThreshold": 10000
 }


### PR DESCRIPTION
Looks like it's a known bug: https://github.com/cypress-io/cypress/issues/18502 or https://github.com/cypress-io/cypress/issues/14972