### PR TITLE
fix(tests): Fix cypress flakiness on CI by slowing down test setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DEBUG: 'cypress:server:socket-base'
+          # DEBUG: 'cypress:server:socket-base'
       - name: Get coverage data
         run: |
           # npm run test:coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Run Cypress tests against Openwhyd server
         uses: cypress-io/github-action@v2.7.2
         with:
-          start: npm run start:coverage --mongoDbDatabase openwhyd_test
+          start: 'npm run start:coverage --mongoDbDatabase openwhyd_test 1>&2'
           config-file: cypress.json
           browser: 'chromium' # to include browser console in cypress logs
           record: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           start: 'npm run start:coverage --mongoDbDatabase openwhyd_test 1>&2'
           config-file: cypress.json
-          browser: 'chromium' # to include browser console in cypress logs
+          browser: 'chrome' # to include browser console in cypress logs
           record: true
           parallel: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
       - name: Run Cypress tests against Openwhyd server
         uses: cypress-io/github-action@v2.7.2
         with:
-          start: 'npm run start:coverage --mongoDbDatabase openwhyd_test 1>&2'
+          start: npm run start:coverage --mongoDbDatabase openwhyd_test
           config-file: cypress.json
           browser: 'chromium' # to include browser console in cypress logs
           record: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         with:
           start: 'npm run start:coverage --mongoDbDatabase openwhyd_test 1>&2'
           config-file: cypress.json
-          browser: 'chrome' # to include browser console in cypress logs
+          browser: 'chromium' # to include browser console in cypress logs
           record: true
           parallel: true
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,7 @@ jobs:
         uses: cypress-io/github-action@v2.7.2
         with:
           start: npm run start:coverage --mongoDbDatabase openwhyd_test
+          wait-on: 'http://localhost:8080'
           config-file: cypress.json
           browser: 'chromium' # to include browser console in cypress logs
           record: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
           # Recommended: pass the GitHub token lets this action correctly
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # DEBUG: 'cypress:*'
+          DEBUG: 'cypress:server:socket-base'
       - name: Get coverage data
         run: |
           # npm run test:coverage

--- a/cypress.json
+++ b/cypress.json
@@ -4,11 +4,11 @@
   "video": true,
   "chromeWebSecurity": false,
   "baseUrl": "http://localhost:8080",
-  "defaultCommandTimeout": 8000,
-  "execTimeout": 60000,
-  "taskTimeout": 60000,
-  "pageLoadTimeout": 120000,
+  "defaultCommandTimeout": 4000,
+  "execTimeout": 5000,
+  "taskTimeout": 5000,
+  "pageLoadTimeout": 10000,
   "requestTimeout": 5000,
-  "responseTimeout": 30000,
-  "slowTestThreshold": 10000
+  "responseTimeout": 5000,
+  "slowTestThreshold": 30000
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -16,7 +16,7 @@ import 'cypress-file-upload';
 // Note: please document these commands in index.d.ts.
 
 Cypress.Commands.add('resetDb', () => {
-  cy.request('POST', `/testing/reset`, {
+  return cy.request('POST', `/testing/reset`, {
     timeout: 20000,
     retryOnStatusCodeFailure: true,
     retryOnNetworkFailure: true,

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -16,11 +16,12 @@ import 'cypress-file-upload';
 // Note: please document these commands in index.d.ts.
 
 Cypress.Commands.add('resetDb', () => {
-  return cy.request('POST', `/testing/reset`, {
-    timeout: 20000,
+  cy.request('POST', `/testing/reset`, {
+    timeout: 5000,
     retryOnStatusCodeFailure: true,
     retryOnNetworkFailure: true,
   });
+  cy.wait(1000);
 });
 
 Cypress.Commands.add('logout', () => {

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -28,6 +28,11 @@ beforeEach(function () {
     body: [],
   });
 
+  cy.intercept('GET', 'https://cdns-files.deezer.com/js/min/dz.js', {
+    statusCode: 200,
+    body: '',
+  });
+
   // reset the db before each it() test, across all files no matter what,
   // as recommended in https://docs.cypress.io/guides/references/best-practices.html#State-reset-should-go-before-each-test
   cy.resetDb();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -28,3 +28,9 @@ beforeEach(function () {
   // Safety: this function will work only against the "openwhyd_test" database.
   // => otherwise, it fail throw and prevent tests from running.
 });
+
+afterEach(function () {
+  return cy.window().then(({ document }) => {
+    document.removeChild(document.documentElement);
+  });
+});

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -22,15 +22,13 @@ import '@applitools/eyes-cypress/commands';
 import './commands';
 
 beforeEach(function () {
+  cy.window().then(({ document }) => {
+    document.removeChild(document.documentElement);
+  });
+
   // reset the db before each it() test, across all files no matter what,
   // as recommended in https://docs.cypress.io/guides/references/best-practices.html#State-reset-should-go-before-each-test
   cy.resetDb();
   // Safety: this function will work only against the "openwhyd_test" database.
   // => otherwise, it fail throw and prevent tests from running.
-});
-
-afterEach(function () {
-  return cy.window().then(({ document }) => {
-    document.removeChild(document.documentElement);
-  });
 });

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -22,10 +22,6 @@ import '@applitools/eyes-cypress/commands';
 import './commands';
 
 beforeEach(function () {
-  cy.window().then(({ document }) => {
-    document.removeChild(document.documentElement);
-  });
-
   // reset the db before each it() test, across all files no matter what,
   // as recommended in https://docs.cypress.io/guides/references/best-practices.html#State-reset-should-go-before-each-test
   cy.resetDb();

--- a/cypress/support/index.ts
+++ b/cypress/support/index.ts
@@ -22,6 +22,12 @@ import '@applitools/eyes-cypress/commands';
 import './commands';
 
 beforeEach(function () {
+  // mock the /api/notif endpoint, to prevent tests from timing out because of dangling calls to that endpoint, preventing the "load" event from firing.
+  cy.intercept('GET', '/api/notif*', {
+    statusCode: 200,
+    body: [],
+  });
+
   // reset the db before each it() test, across all files no matter what,
   // as recommended in https://docs.cypress.io/guides/references/best-practices.html#State-reset-should-go-before-each-test
   cy.resetDb();

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -1,4 +1,4 @@
-@font-face {
+/* @font-face {
   font-family: 'AvenirNext-Regular';
   src: url(/fonts/AvenirNext-Regular.eot);
   src: url(/fonts/AvenirNext-Regular.eot?#iefix) format('embedded-opentype'),
@@ -32,7 +32,7 @@
     url(/fonts/AvenirNext-DemiBold.svg#AvenirNext-DemiBold) format('svg');
   font-weight: normal;
   font-style: normal;
-}
+} */
 
 h1,
 h2,

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -1,23 +1,13 @@
-/* @font-face {
+@font-face {
   font-family: 'AvenirNext-Regular';
-  src: url(/fonts/AvenirNext-Regular.eot);
-  src: url(/fonts/AvenirNext-Regular.eot?#iefix) format('embedded-opentype'),
-    url(/fonts/AvenirNext-Regular.woff) format('woff'),
-    url(/fonts/AvenirNext-Regular.otf) format('opentype'),
-    url(/fonts/AvenirNext-Regular.ttf) format('truetype'),
-    url(/fonts/AvenirNext-Regular.svg#AvenirNext-Regular) format('svg');
+  src: url(/fonts/AvenirNext-Regular.woff) format('woff');
   font-weight: normal;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'AvenirNext-Medium', Helvetica, Arial, Sans-serif;
-  src: url(/fonts/AvenirNext-Medium.eot);
-  src: url(/fonts/AvenirNext-Medium.eot?#iefix) format('embedded-opentype'),
-    url(/fonts/AvenirNext-Medium.otf) format('opentype'),
-    url(/fonts/AvenirNext-Medium.woff) format('woff'),
-    url(/fonts/AvenirNext-Medium.ttf) format('truetype'),
-    url(/fonts/AvenirNext-Medium.svg#AvenirNext-Medium) format('svg');
+  src: url(/fonts/AvenirNext-Medium.woff) format('woff');
   font-weight: normal;
   font-style: normal;
 }
@@ -25,14 +15,10 @@
 @font-face {
   font-family: 'AvenirNext-DemiBold', Helvetica, Arial, Sans-serif;
   font-weight: bold;
-  src: url(/fonts/AvenirNext-DemiBold.eot);
-  src: url(/fonts/AvenirNext-DemiBold.eot?#iefix) format('embedded-opentype'),
-    url(/fonts/AvenirNext-DemiBold.woff) format('woff'),
-    url(/fonts/AvenirNext-DemiBold.ttf) format('truetype'),
-    url(/fonts/AvenirNext-DemiBold.svg#AvenirNext-DemiBold) format('svg');
+  src: url(/fonts/AvenirNext-DemiBold.woff) format('woff');
   font-weight: normal;
   font-style: normal;
-} */
+}
 
 h1,
 h2,

--- a/public/js/whyd.js
+++ b/public/js/whyd.js
@@ -899,12 +899,12 @@ $(document).ready(function () {
 
   // init notifications
 
-  var notifUpdateInterval = 20000;
+  // var notifUpdateInterval = 20000;
   $notifPanel = $('#notifPanel');
   $notifIcon = $('#notifIcon');
 
-  window.setInterval(fetchNotifs, notifUpdateInterval);
-  fetchNotifs();
+  // window.setInterval(fetchNotifs, notifUpdateInterval); // TODO
+  // fetchNotifs(); // TODO
 
   $notifIcon.click(function () {
     if ($(this).text() == 0) return $notifPanel.hide();

--- a/public/js/whyd.js
+++ b/public/js/whyd.js
@@ -899,12 +899,12 @@ $(document).ready(function () {
 
   // init notifications
 
-  // var notifUpdateInterval = 20000;
+  var notifUpdateInterval = 20000;
   $notifPanel = $('#notifPanel');
   $notifIcon = $('#notifIcon');
 
-  // window.setInterval(fetchNotifs, notifUpdateInterval); // TODO
-  // fetchNotifs(); // TODO
+  window.setInterval(fetchNotifs, notifUpdateInterval);
+  fetchNotifs();
 
   $notifIcon.click(function () {
     if ($(this).text() == 0) return $notifPanel.hide();


### PR DESCRIPTION
## Problem

Despite several attempts to improve the situation (see PRs #501, #504, #505, #507, #508, #510, #513, #520, #521, #522), Cypress tests are still flaky: they timeout for random reasons.

## Hypothesis

This timeout could be caused by the fact that:
- some XHR requests (e.g. to `/api/notif` to fetch notifications, and Deezer) may never respond => `onLoad` is never triggered
- when a new test starts, we call `/testing/reset` to refresh the DB, which can cause pending DB queries from never resolving

See https://github.com/openwhyd/openwhyd/pull/520#issuecomment-997704287.

## Proposed solution

- wait for Openwhyd server to be up and reset before running tests
- intercept and mock flaky XHR requests
- fail faster when test steps are hanging for too long
- reduce the amount of resources to load: fonts