### PR TITLE
feat(api): Enable JSONP API for list of playlists

### DIFF
--- a/app/controllers/LibUser.js
+++ b/app/controllers/LibUser.js
@@ -152,8 +152,9 @@ function renderUserLinks(lnk) {
 function renderResponse(feed, options, lib, user) {
   if (options.callback) {
     var safeCallback = options.callback.replace(/[^a-z0-9_]/gi, '');
+    const data = options.showPlaylists ? options.playlists : feed;
     lib.renderOther(
-      safeCallback + '(' + JSON.stringify(feed) + ')',
+      safeCallback + '(' + JSON.stringify(data) + ')',
       'application/javascript'
     );
   } else if (options.format == 'links') {

--- a/docs/API.md
+++ b/docs/API.md
@@ -20,7 +20,8 @@ The goal of the Data Export API is to give free access to data that users public
 
 This API can be used by anyone, without authentication, to download the list of tracks of:
 
-- a user profile; (e.g. https://openwhyd.org/adrien)
+- a user's list of posts; (e.g. https://openwhyd.org/adrien)
+- a user's list of playlists (e.g. https://openwhyd.org/adrien/playlists)
 - a playlist; (e.g. https://openwhyd.org/adrien/playlist/61)
 - or "hot tracks". (e.g. https://openwhyd.org/hot/electro)
 
@@ -35,11 +36,12 @@ Please use these URLs responsibly: add a reasonable delay between requests, in o
 
 <!-- exported from https://whyd.hackpad.com/Early-API-Download-Whyd-track-listings-in-JSON-format-CTMZ8XxzRuB -->
 
-A list of tracks can be downloaded by appending the following HTTP GET parameters to Openwhyd URLs:
+A list of tracks (or playlists) can be downloaded by appending the following HTTP GET parameters to Openwhyd URLs:
 
 - `format`: "`json`" or "`links`"
 - `limit`: number of posts to return (optional, default=`20`)
 - `after`: identifier of the post (a.k.a. `pId`) from which entries must be returned (optional, for pagination)
+- `callback`: (optional) name of the JavaScript function to which data will be passed as a parameter (for JSONP access from external domains)
 
 ### Examples
 

--- a/test/integration/data.api.tests.js
+++ b/test/integration/data.api.tests.js
@@ -135,6 +135,21 @@ describe(`Data Export API`, () => {
   });
 
   describe(`provides playlist tracks`, () => {
+    it(`of given user id, as JSON, using callback`, async () => {
+      const { body } = await reqGet(
+        `${URL_PREFIX}/u/${user.id}/playlist/0?callback=callbackFct`
+      );
+      let apiResponse;
+      vm.runInNewContext(body, {
+        callbackFct: (data) => {
+          apiResponse = data;
+        },
+      });
+      assert.strictEqual(apiResponse.error, undefined);
+      assert.strictEqual(apiResponse.length, 1);
+      assert.strictEqual(apiResponse[0].name, track.name);
+    });
+
     it(`of given user id, as JSON`, async () => {
       const plUrl = `${URL_PREFIX}/u/${user.id}/playlist/0`;
       const { body } = await reqGet(`${plUrl}?format=json`);

--- a/test/integration/data.api.tests.js
+++ b/test/integration/data.api.tests.js
@@ -1,3 +1,4 @@
+const vm = require('vm');
 const assert = require('assert');
 const request = require('request');
 
@@ -40,6 +41,21 @@ describe(`Data Export API`, () => {
   });
 
   describe(`provides profile tracks`, () => {
+    it(`of given user id, as JSON, using callback`, async () => {
+      const { body } = await reqGet(
+        `${URL_PREFIX}/u/${user.id}?format=json&callback=callbackFct`
+      );
+      let apiResponse;
+      vm.runInNewContext(body, {
+        callbackFct: (data) => {
+          apiResponse = data;
+        },
+      });
+      assert.strictEqual(apiResponse.error, undefined);
+      assert.strictEqual(apiResponse.length, 1);
+      assert.strictEqual(apiResponse[0].name, track.name);
+    });
+
     it(`of given user id, as JSON`, async () => {
       const { body } = await reqGet(`${URL_PREFIX}/u/${user.id}?format=json`);
       const parsedBody = JSON.parse(body) || {};

--- a/test/integration/data.api.tests.js
+++ b/test/integration/data.api.tests.js
@@ -86,6 +86,21 @@ describe(`Data Export API`, () => {
   });
 
   describe(`provides list of playlists`, () => {
+    it(`of given user id, as JSON, using callback`, async () => {
+      const { body } = await reqGet(
+        `${URL_PREFIX}/u/${user.id}/playlists?format=json&callback=callbackFct`
+      );
+      let apiResponse;
+      vm.runInNewContext(body, {
+        callbackFct: (data) => {
+          apiResponse = data;
+        },
+      });
+      assert.strictEqual(apiResponse.error, undefined);
+      assert.strictEqual(apiResponse.length, 1);
+      assert.strictEqual(apiResponse[0].name, plName);
+    });
+
     it(`of given user id, as JSON`, async () => {
       const plUrl = `${URL_PREFIX}/u/${user.id}/playlists`;
       const { body } = await reqGet(`${plUrl}?format=json`);

--- a/test/integration/data.api.tests.js
+++ b/test/integration/data.api.tests.js
@@ -43,7 +43,7 @@ describe(`Data Export API`, () => {
   describe(`provides profile tracks`, () => {
     it(`of given user id, as JSON, using callback`, async () => {
       const { body } = await reqGet(
-        `${URL_PREFIX}/u/${user.id}?format=json&callback=callbackFct`
+        `${URL_PREFIX}/u/${user.id}?callback=callbackFct`
       );
       let apiResponse;
       vm.runInNewContext(body, {
@@ -88,7 +88,7 @@ describe(`Data Export API`, () => {
   describe(`provides list of playlists`, () => {
     it(`of given user id, as JSON, using callback`, async () => {
       const { body } = await reqGet(
-        `${URL_PREFIX}/u/${user.id}/playlists?format=json&callback=callbackFct`
+        `${URL_PREFIX}/u/${user.id}/playlists?callback=callbackFct`
       );
       let apiResponse;
       vm.runInNewContext(body, {


### PR DESCRIPTION
To support the development of an external/static web clients (e.g. https://glitch.com/edit/#!/openwhyd-mobile-client?path=TrackFinder.js%3A294%3A0).