### PR TITLE
tests: Run unit and functional tests with Wallaby

### DIFF
--- a/wallaby.conf.js
+++ b/wallaby.conf.js
@@ -1,0 +1,15 @@
+// See https://wallabyjs.com/docs/intro/config.html#configuration-file
+
+module.exports = function (/*wallaby*/) {
+  return {
+    env: {
+      type: 'node', // see https://wallabyjs.com/docs/integration/node.html
+      runner: `${require('os').homedir()}/.nvm/versions/node/${require('fs')
+        .readFileSync('./.nvmrc')
+        .toString()
+        .trim()}/bin/node`,
+    },
+    files: ['app/**/*.js', 'public/**/*.js', 'public/html/test-resources/*.*'],
+    tests: ['test/unit/*-tests.js'],
+  };
+};


### PR DESCRIPTION
Second tentative of https://github.com/openwhyd/openwhyd/pull/557, with unit and functional tests. (for now)

Done during [SHODAY 2022-05-09](https://github.com/openwhyd/openwhyd/issues/559).

See resulting screenshots in VSCode: https://github.com/openwhyd/openwhyd/pull/565#issuecomment-1121185962.

## How to use

1. Install Wallaby's extension on VS Code, cf [Wallaby.js Tutorials: VS Code tutorial](https://wallabyjs.com/docs/intro/get-started-vscode.html?port=56094#remote-containers)
2. Open openwhyd's local repository in VS Code
3. Activate the "Wallaby.js: Select Configuration" command, using VSCode's palette (Cmd-Shift-P), then select the `wallaby.conf.js` file
4. Run the tests by activating the "Wallaby.js: Start" command, thru VSCode's palette or Wallaby's palette (Cmd-Shift-=)
5. Open the "Output" panel (usually at the bottom of VSCode), then pick the "Wallaby.js Tests" to see test execution logs
6. Command-click the "​Launch Coverage & Test Explorer​" hyperlink to open Wallaby's test explorer in your web browser.

## Refs

- [Wallaby.js Configuration file: Files and tests](https://wallabyjs.com/docs/config/files.html)
- [Wallaby.js Introduction: Troubleshooting](https://wallabyjs.com/docs/intro/troubleshooting.html#:~:text='Cannot%20find%20module'%20or%20',to%20copy%20used%20files%20there.)

## Notes

- Wallaby is suitable for fast-running tests only (see https://github.com/wallabyjs/public/issues/1792#issuecomment-839458752) => let's not aim to run our Cypress-based end-to-end tests with it.
- "Wallaby does not currently support running/reporting on your tests/code from spawned processes" (cf https://github.com/wallabyjs/public/issues/359#issuecomment-713884398) => We'd have to change the way Openwhyd's server is started programmatically for API/integration tests