### PR TITLE
fix(cypress): prevent browserVersion mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,6 +270,12 @@ jobs:
         # run 3 copies of the current job in parallel
         containers: [1, 2, 3]
     steps:
+      # to avoid browserVersion mismatch, cf https://github.com/cypress-io/github-action/issues/518#issuecomment-1210979047
+      - uses: browser-actions/setup-chrome@latest
+      - run: |
+          echo "Chrome version: $(which chrome)"
+          echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
+
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## What does this PR do / solve?

Cf https://github.com/openwhyd/openwhyd/actions/runs/5587330707/jobs/10212532677#step:8:125:

```
You passed the --parallel flag, but we do not parallelize tests across different environments.

This machine is sending different environment parameters than the first machine that started this parallel run.

The existing run is: https://cloud.cypress.io/projects/8mw8bh/runs

In order to run in parallel mode each machine must send identical environment parameters such as:

 - specs
 - osName
 - osVersion
 - browserName
 - browserVersion (major)

This machine sent the following parameters:

{
  "osName": "linux",
  "osVersion": "Ubuntu - ",
  "browserName": "Chromium",
  "browserVersion": "113.0.5672.0.... (Expected: 114)",
  "specs": [
    "cypress/e2e/acceptance.spec.ts",
    "cypress/e2e/bookmarklet.spec.ts",
    "cypress/e2e/email-notification.spec.ts",
    "cypress/e2e/playback.spec.ts",
    "cypress/e2e/stream.spec.ts",
    "cypress/e2e/upload.spec.ts",
    "cypress/e2e/visual-snapshots.ts"
  ]
}

https://on.cypress.io/parallel-group-params-mismatch
```

## Overview of changes

Solution: https://github.com/cypress-io/github-action/issues/518#issuecomment-1210979047
