### PR TITLE
fix(algolia): prevent http 502 errors on indexing operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
       - env:
           CI: true
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
-          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_READONLY_TEST_API_KEY }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_TEST_API_KEY }}
         run: npm run test:3rd-party
 
   refactor-coverage:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,27 @@ jobs:
           MONGODB_URL: 'mongodb://localhost:27017/openwhyd_test'
         run: npm run test:integration
 
+  third-party-tests:
+    name: 3rd-party tests
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    timeout-minutes: 5
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+      - name: npm install
+        env:
+          CI: true
+        run: npm install --prefer-offline --no-audit
+      - env:
+          CI: true
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_READONLY_TEST_API_KEY }}
+        run: npm run test:3rd-party
+
   refactor-coverage:
     name: Send test coverage of the `post` API to Codacy
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
@@ -389,6 +410,7 @@ jobs:
       - unit-tests
       - integration-tests
       - cypress-tests
+      - third-party-tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-20.04
     steps:

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -330,6 +330,10 @@ exports.countDocs = function (type, callback) {
 };
 
 exports.deleteAllDocs = function (type, callback) {
+  if (!INDEX_NAME_BY_TYPE[type]) {
+    callback && callback(new Error('invalid type'));
+    return;
+  }
   getIndex(INDEX_NAME_BY_TYPE[type]).clearIndex(function (err) {
     console.log('[search] algolia deleteAllDocs =>', err || 'ok');
     callback && callback(); // TODO: check if parameters are required or not

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -304,10 +304,10 @@ exports.indexTyped = function (type, item, handler) {
   //console.log("models.search.index(): ", item, "...");
   if (!item || !item._id || !item.name) {
     logToConsole({ error: 'indexTyped: missing parameters' });
-    handler && handler(); // TODO: check if parameters are required or not
+    handler && handler(new Error('indexTyped: missing parameters'));
   }
-  return indexTypedDocs(type, [item], function () {
-    handler && handler(); // TODO: check if parameters are required or not
+  return indexTypedDocs(type, [item], function (err, success) {
+    handler && handler(err, success);
   });
 };
 

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -308,6 +308,7 @@ exports.indexTyped = function (type, item, handler) {
   if (!item || !item._id || !item.name) {
     logToConsole({ error: 'indexTyped: missing parameters' });
     handler && handler(new Error('indexTyped: missing parameters'));
+    return;
   }
   return indexTypedDocs(type, [item], function (err, success) {
     handler && handler(err, success);

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -278,8 +278,10 @@ function indexTypedDocs(type, items, callback) {
       });
       return doc;
     });
-    getIndex(INDEX_NAME_BY_TYPE[type]).addObjects(docs, function (err) {
-      if (err) {
+
+    getIndex(INDEX_NAME_BY_TYPE[type])
+      .saveObjects(docs, { autoGenerateObjectIDIfNotExist: true })
+      .catch((err) => {
         console.error(
           '[search] algolia error when indexing ' +
             items.length +
@@ -288,15 +290,16 @@ function indexTypedDocs(type, items, callback) {
             ' items => ' +
             err.toString()
         );
-      } else {
+        callback && callback(err);
+      })
+      .then(() => {
         console.log(
           '[search] algolia indexTyped ' + type + ' => indexed',
           items.length,
           'documents'
         );
-      }
-      callback && callback(err, { items: items });
-    });
+        callback && callback(null, { items: items });
+      });
   }
 }
 

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -319,18 +319,22 @@ exports.indexTyped = function (type, item, handler) {
 };
 
 exports.countDocs = function (type, callback) {
-  ENGINE.listIndexes(function (err, content) {
-    try {
-      callback(
-        content.items.find(function (index) {
-          return index.name === INDEX_NAME_BY_TYPE[type];
-        }).entries
-      );
-    } catch (e) {
-      console.error('[search]', err || e);
+  ENGINE.listIndices()
+    .catch((err) => {
+      console.error('[search]', err);
       callback(null);
-    }
-  });
+    })
+    .then(function (content) {
+      try {
+        const count = content.items.find(function (index) {
+          return index.name === INDEX_NAME_BY_TYPE[type];
+        }).entries;
+        callback(count);
+      } catch (e) {
+        console.error('[search]', e);
+        callback(null);
+      }
+    });
 };
 
 exports.deleteAllDocs = function (type, callback) {

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -284,6 +284,7 @@ function indexTypedDocs(type, items, callback) {
 
     getIndex(INDEX_NAME_BY_TYPE[type])
       .saveObjects(docs, { autoGenerateObjectIDIfNotExist: true })
+      .wait()
       .catch((err) => {
         console.error(
           '[search] algolia error when indexing ' +

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -9,7 +9,7 @@ var Algolia = require('algoliasearch');
 
 var ENGINE = new Algolia(
   process.env.ALGOLIA_APP_ID.substr(),
-  process.env.ALGOLIA_API_KEY.substr()
+  process.env.ALGOLIA_API_KEY.substr() // required ACLs: search, browse, addObject, deleteObject, listIndexes, editSettings
 );
 
 var INDEX_NAME_BY_TYPE = {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:post:coverage": "rm -rf .nyc_output coverage && COVERAGE=true npm run test:unit -- --serial && COVERAGE=true npm run test:functional -- --serial && COVERAGE=true npm run test:approval -- --serial --timeout 10000 && COVERAGE=true npm run test:integration:post -- --serial --timeout 10000 && npx nyc report --reporter=lcov && npx nyc report | grep post",
     "test:cypress:dev": "node_modules/.bin/cypress open",
     "test:cypress": "node_modules/.bin/cypress run",
+    "test:3rd-party": "jest test/3rd-party/*.test.js",
     "test": ". ./env-vars-testing.sh && npm run test:unit && npm run test:integration && npm run test:cypress",
     "test:coverage": "npx nyc report --reporter=text-summary  --reporter=lcov",
     "docker:seed": "docker-compose exec web npm run test-reset && docker-compose restart web && ./scripts/wait-for-http-server.sh 8080",

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -35,12 +35,23 @@ describe('Algolia search wrapper', () => {
   //   await expect(promise).rejects.toThrow('Not enough rights to add an object');
   // });
 
-  it('should index a post', async () => {
+  it('should index then find a post', async () => {
     const post = {
       _id: 'xyz',
       name: 'a post',
     };
     const result = await util.promisify(searchModel.indexTyped)('post', post);
     expect(result).toMatchObject({ items: [post] });
+
+    const posts = await new Promise((resolve) =>
+      searchModel.query(
+        {
+          _type: 'post',
+          q: '',
+        },
+        resolve
+      )
+    );
+    expect(posts).toMatchObject({ hits: [post] });
   });
 });

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -35,6 +35,6 @@ describe('Algolia search wrapper', () => {
       name: 'a post',
     };
     const result = await util.promisify(searchModel.indexTyped)('post', post);
-    expect(result).toMatch({ items: [post] });
+    expect(result).toMatchObject({ items: [post] });
   });
 });

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -13,6 +13,11 @@ describe('Algolia search wrapper', () => {
     searchModel = require('../../app/models/search.js');
   });
 
+  it('should fail to delete unknown type of documents', async () => {
+    const promise = util.promisify(searchModel.deleteAllDocs)('whatever');
+    await expect(promise).rejects.toThrow('invalid type');
+  });
+
   it('should fail to index a post if name is missing', async () => {
     const promise = util.promisify(searchModel.indexTyped)('post', {
       _id: 'xyz',

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -20,12 +20,21 @@ describe('Algolia search wrapper', () => {
     await expect(promise).rejects.toThrow('indexTyped: missing parameters');
   });
 
+  // TODO
+  // it('should fail to index a post thru a readonly API key', async () => {
+  //   const promise = util.promisify(searchModel.indexTyped)('post', {
+  //     _id: 'xyz',
+  //     name: 'a post',
+  //   });
+  //   await expect(promise).rejects.toThrow('Not enough rights to add an object');
+  // });
+
   it('should index a post', async () => {
-    const result = await util.promisify(searchModel.indexTyped)('post', {
+    const post = {
       _id: 'xyz',
       name: 'a post',
-    });
-
-    console.log({ result });
+    };
+    const result = await util.promisify(searchModel.indexTyped)('post', post);
+    expect(result).toMatch({ items: [post] });
   });
 });

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -5,13 +5,21 @@ const util = require('util');
 describe('Algolia search wrapper', () => {
   let searchModel;
 
+  const cleanUp = async () => {
+    await util.promisify(searchModel.deleteAllDocs)('post');
+  };
+
   // init with provided credentials + clean up
   beforeAll(async () => {
     expect(process.env).toHaveProperty('ALGOLIA_APP_ID');
     expect(process.env).toHaveProperty('ALGOLIA_API_KEY');
     process.appParams = { searchModule: 'searchAlgolia' };
     searchModel = require('../../app/models/search.js');
-    await util.promisify(searchModel.deleteAllDocs)('post');
+    await cleanUp();
+  });
+
+  afterAll(async () => {
+    await cleanUp();
   });
 
   it('should fail to delete unknown type of documents', async () => {

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -1,0 +1,21 @@
+// $ ALGOLIA_APP_ID="XXXXX" ALGOLIA_API_KEY="YYYYY" npx jest test/3rd-party/algoliasearch.test.js
+
+describe('Algolia search wrapper', () => {
+  let searchModel;
+
+  // init with provided credentials
+  beforeAll(() => {
+    expect(process.env).toHaveProperty('ALGOLIA_APP_ID');
+    expect(process.env).toHaveProperty('ALGOLIA_API_KEY');
+    process.appParams = { searchModule: 'searchAlgolia' };
+    searchModel = require('../../app/models/search.js');
+  });
+
+  it('should index a post', () => {
+    const result = searchModel.indexTyped('post', {
+      _id: 'xyz',
+      name: 'a post',
+    });
+    console.log({ result });
+  });
+});

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -5,12 +5,13 @@ const util = require('util');
 describe('Algolia search wrapper', () => {
   let searchModel;
 
-  // init with provided credentials
-  beforeAll(() => {
+  // init with provided credentials + clean up
+  beforeAll(async () => {
     expect(process.env).toHaveProperty('ALGOLIA_APP_ID');
     expect(process.env).toHaveProperty('ALGOLIA_API_KEY');
     process.appParams = { searchModule: 'searchAlgolia' };
     searchModel = require('../../app/models/search.js');
+    await util.promisify(searchModel.deleteAllDocs)('post');
   });
 
   it('should fail to delete unknown type of documents', async () => {

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -34,14 +34,12 @@ describe('Algolia search wrapper', () => {
     await expect(promise).rejects.toThrow('indexTyped: missing parameters');
   });
 
-  // TODO
-  // it('should fail to index a post thru a readonly API key', async () => {
-  //   const promise = util.promisify(searchModel.indexTyped)('post', {
-  //     _id: 'xyz',
-  //     name: 'a post',
-  //   });
-  //   await expect(promise).rejects.toThrow('Not enough rights to add an object');
-  // });
+  it('should count number of documents per index', async () => {
+    const count = await new Promise((resolve) =>
+      searchModel.countDocs('post', resolve)
+    );
+    await expect(count).toBe(0);
+  });
 
   it('should index then find a post', async () => {
     const post = {

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -1,5 +1,7 @@
 // $ ALGOLIA_APP_ID="XXXXX" ALGOLIA_API_KEY="YYYYY" npx jest test/3rd-party/algoliasearch.test.js
 
+const util = require('util');
+
 describe('Algolia search wrapper', () => {
   let searchModel;
 
@@ -11,11 +13,19 @@ describe('Algolia search wrapper', () => {
     searchModel = require('../../app/models/search.js');
   });
 
-  it('should index a post', () => {
-    const result = searchModel.indexTyped('post', {
+  it('should fail to index a post if name is missing', async () => {
+    const promise = util.promisify(searchModel.indexTyped)('post', {
+      _id: 'xyz',
+    });
+    await expect(promise).rejects.toThrow('indexTyped: missing parameters');
+  });
+
+  it('should index a post', async () => {
+    const result = await util.promisify(searchModel.indexTyped)('post', {
       _id: 'xyz',
       name: 'a post',
     });
+
     console.log({ result });
   });
 });


### PR DESCRIPTION
Fixes #612.

## What does this PR do / solve?

HTTP `502` errors when posting tracks and updating user data, caused by `getIndex(...).addObjects is not a function` errors from `searchAlgolia.js` wrapper.

Because `addObjects` is deprecated, cf: https://www.algolia.com/doc/deprecated/api-clients/javascript/v3/methods/add-objects/.

## Overview of changes

- reproduce problem in a 3rd-party test.
- run 3rd-party tests on CI.
- fix the problematic call to algoliasearch.

## How to test this PR?

```
$ ALGOLIA_APP_ID="XXXXX" ALGOLIA_API_KEY="YYYYY" npx jest test/3rd-party/algoliasearch.test.js
```