### PR TITLE
fix(algolia): finish algoliasearch upgrade migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,9 @@ jobs:
         run: |
           npm run start:coverage --mongoDbDatabase openwhyd_test &
           ./scripts/wait-for-http-server.sh 8080 # give openwhyd's server some time to start
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_TEST_API_KEY }}
       - name: Approval tests
         env:
           PORT: '8080'
@@ -344,6 +347,8 @@ jobs:
           # determine the unique run id necessary to re-run the checks
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # DEBUG: 'cypress:server:socket-base'
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_TEST_API_KEY }}
       - name: Get coverage data
         run: |
           # npm run test:coverage
@@ -459,6 +464,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Build and start services
         run: docker-compose up --build --detach
+        env:
+          ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
+          ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_TEST_API_KEY }}
       - name: Init database for tests
         run: |
           docker-compose exec -T web npm run test-reset

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -247,7 +247,7 @@ exports.savePost = function (postObj, handler) {
     if (error) console.error('post.savePost() error: ', error);
     if (result) {
       if (Array.isArray(result)) result = result[0];
-      // searchModel.indexTyped('post', result); // TODO: re-enable seach, cf https://github.com/openwhyd/openwhyd/issues/612
+      searchModel.indexTyped('post', result);
       result.isNew = !pId;
       if (result.isNew) notif.post(result);
       notifyMentionedUsers(result);
@@ -325,7 +325,7 @@ exports.rePost = function (pId, repostObj, handler) {
       if (result && result.length) {
         //searchModel.indexPost(result);
         result = result[0];
-        // searchModel.indexTyped('post', result); // TODO: re-enable seach, cf https://github.com/openwhyd/openwhyd/issues/612
+        searchModel.indexTyped('post', result);
         notifyMentionedUsers(result);
       }
       handler(result);

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -5,9 +5,9 @@
 
 var snip = require('../snip.js');
 var mongodb = require('./mongodb.js');
-var Algolia = require('algoliasearch');
+const algoliasearch = require('algoliasearch');
 
-var ENGINE = new Algolia(
+const client = algoliasearch(
   process.env.ALGOLIA_APP_ID.substr(),
   process.env.ALGOLIA_API_KEY.substr() // required ACLs: search, browse, addObject, deleteObject, listIndexes, editSettings, deleteIndex
 );
@@ -52,7 +52,7 @@ var getIndex = (function () {
   return function (indexName) {
     var index = INDEX[indexName];
     if (!index) {
-      index = INDEX[indexName] = ENGINE.initIndex(indexName);
+      index = INDEX[indexName] = client.initIndex(indexName);
       // init field indexing settings
       var fields = INDEX_FIELDS_BY_TYPE[INDEX_TYPE_BY_NAME[indexName]] || [];
       index.setSettings({
@@ -97,7 +97,7 @@ Search.prototype.search = function (index, query, options, cb) {
       options.index = index;
       options.query = q;
       this.queries.push(options);
-      ENGINE.multipleQueries(this.queries, 'index', cb); // TODO: make sure that this still works
+      client.multipleQueries(this.queries, 'index', cb); // TODO: make sure that this still works
     } else {
       getIndex(index)
         .search(q, options)
@@ -320,7 +320,8 @@ exports.indexTyped = function (type, item, handler) {
 };
 
 exports.countDocs = function (type, callback) {
-  ENGINE.listIndices()
+  client
+    .listIndices()
     .catch((err) => {
       console.error('[search]', err);
       callback(null);

--- a/app/models/searchAlgolia.js
+++ b/app/models/searchAlgolia.js
@@ -92,24 +92,16 @@ Search.prototype.search = function (index, query, options, cb) {
     options.facets = facetAttrs.join(',');
     options.facetFilters = facetFilters;
   }
-  if (cb) {
-    if (this.queries) {
-      options.index = index;
-      options.query = q;
-      this.queries.push(options);
-      client.multipleQueries(this.queries, 'index', cb); // TODO: make sure that this still works
-    } else {
-      getIndex(index)
-        .search(q, options)
-        .catch(cb)
-        .then((success) => cb(null, success));
-    }
-  } else {
-    options.index = index;
-    options.query = q;
-    this.queries = this.queries || [];
-    this.queries.push(options);
+  if (!cb) {
+    throw new Error(
+      'please pass a callback parameter when calling Search.prototype.search'
+    );
   }
+  getIndex(index)
+    .search(q, options)
+    .catch(cb)
+    .then((success) => cb(null, success));
+
   return this;
 };
 

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -360,7 +360,7 @@ exports.save = function (pUser, handler) {
         if (err) console.error(err);
         //console.log("user stored as ", user);
         // @ts-ignore
-        // if (user) searchModel.indexTyped('user', user); // TODO: re-enable seach, cf https://github.com/openwhyd/openwhyd/issues/612
+        if (user) searchModel.indexTyped('user', user);
         mongodb.cacheUser(user);
         if (handler) handler(user);
       });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,5 @@ services:
       - DISABLE_DATADOG=true
       - MONGODB_HOST=mongo
       - MONGODB_PORT=27117
+      - ALGOLIA_APP_ID
+      - ALGOLIA_API_KEY

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -7,6 +7,8 @@ describe('Algolia search wrapper', () => {
 
   const cleanUp = async () => {
     await util.promisify(searchModel.deleteAllDocs)('post');
+    await util.promisify(searchModel.deleteAllDocs)('playlist');
+    await util.promisify(searchModel.deleteAllDocs)('user');
   };
 
   // init with provided credentials + clean up
@@ -70,12 +72,7 @@ describe('Algolia search wrapper', () => {
     expect(result).toMatchObject({ items: [post] });
 
     const posts = await new Promise((resolve) =>
-      searchModel.query(
-        {
-          q: '',
-        },
-        resolve
-      )
+      searchModel.query({ q: '' }, resolve)
     );
     expect(posts).toMatchObject({ hits: [post] });
   });

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -2,6 +2,11 @@
 
 const util = require('util');
 
+const DUMMY_POST = {
+  _id: 'xyz',
+  name: 'a post',
+};
+
 describe('Algolia search wrapper', () => {
   let searchModel;
 
@@ -44,30 +49,18 @@ describe('Algolia search wrapper', () => {
   });
 
   it('should hit an indexed post, when searching posts', async () => {
-    const post = {
-      _id: 'xyz',
-      name: 'a post',
-    };
+    const post = DUMMY_POST;
     const result = await util.promisify(searchModel.indexTyped)('post', post);
     expect(result).toMatchObject({ items: [post] });
 
     const posts = await new Promise((resolve) =>
-      searchModel.query(
-        {
-          _type: 'post',
-          q: '',
-        },
-        resolve
-      )
+      searchModel.query({ _type: 'post', q: '' }, resolve)
     );
     expect(posts).toMatchObject({ hits: [post] });
   });
 
   it('should hit an indexed post, when searching all types of documents', async () => {
-    const post = {
-      _id: 'xyz',
-      name: 'a post',
-    };
+    const post = DUMMY_POST;
     const result = await util.promisify(searchModel.indexTyped)('post', post);
     expect(result).toMatchObject({ items: [post] });
 

--- a/test/3rd-party/algoliasearch.test.js
+++ b/test/3rd-party/algoliasearch.test.js
@@ -41,7 +41,7 @@ describe('Algolia search wrapper', () => {
     await expect(count).toBe(0);
   });
 
-  it('should index then find a post', async () => {
+  it('should hit an indexed post, when searching posts', async () => {
     const post = {
       _id: 'xyz',
       name: 'a post',
@@ -53,6 +53,25 @@ describe('Algolia search wrapper', () => {
       searchModel.query(
         {
           _type: 'post',
+          q: '',
+        },
+        resolve
+      )
+    );
+    expect(posts).toMatchObject({ hits: [post] });
+  });
+
+  it('should hit an indexed post, when searching all types of documents', async () => {
+    const post = {
+      _id: 'xyz',
+      name: 'a post',
+    };
+    const result = await util.promisify(searchModel.indexTyped)('post', post);
+    expect(result).toMatchObject({ items: [post] });
+
+    const posts = await new Promise((resolve) =>
+      searchModel.query(
+        {
           q: '',
         },
         resolve


### PR DESCRIPTION
Fixes #612.

## What does this PR do / solve?

- Finish migration from `algoliasearch` v3 to v4 (cf https://github.com/openwhyd/openwhyd/issues/612#issuecomment-1646585205), by following [their migration guide](https://www.algolia.com/doc/api-client/getting-started/update/javascript/?client=javascript)
- Re-enables indexing to Algolia

## Overview of changes

- Also removes a unused feature: sending multiple/batched search queries
