### PR TITLE
fix: simplify db initialization script

### DIFF
--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -5,6 +5,7 @@ var mongodb = require('mongodb');
 
 const PRINT_ACTIVE = false;
 const LOG_PREFIX = '[mongo shell]';
+const TIMEOUT_MS = 2 * 60 * 1000; // two minutes
 
 function buildContext(db, callback) {
   const context = {
@@ -30,7 +31,7 @@ exports.runScriptOnDatabase = function (script, db, callback) {
       await vm.runInNewContext(
         `Promise.resolve().then(async () => { ${script} });`,
         vm.createContext(contextObj),
-        { timeout: 5, microtaskMode: 'afterEvaluate' },
+        { timeout: TIMEOUT_MS, microtaskMode: 'afterEvaluate' },
       );
     }
     callback(err);

--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -27,7 +27,7 @@ exports.runScriptOnDatabase = function (script, db, callback) {
     if (err) {
       callback(err);
       return;
-    };
+    }
     new vm.Script(script).runInContext(vm.createContext(context));
   });
   callback();

--- a/config/initdb.js
+++ b/config/initdb.js
@@ -1,63 +1,70 @@
 /* globals db */
 
-// Usage: this file should be run by mongo's CLI:
-// $ mongo openwhyd_data whydDB/initdb.js
+// Usage: this file should be run by mongodb-shell-runner.js, on startup
 
 //print("connecting to openwhyd_data database...");
 //db = db.getSiblingDB("openwhyd_data"); //connect("localhost:27017/whyd_music");
 
 print('creating openwhyd collections...');
-db.createCollection('config');
-db.createCollection('email');
-db.createCollection('invite');
-db.createCollection('notif');
-db.createCollection('user');
-db.createCollection('follow');
-db.createCollection('post');
-db.createCollection('activity');
-db.createCollection('track');
-db.createCollection('comment');
+await Promise.all([
+  db.createCollection('config'),
+  db.createCollection('email'),
+  db.createCollection('invite'),
+  db.createCollection('notif'),
+  db.createCollection('user'),
+  db.createCollection('follow'),
+  db.createCollection('post'),
+  db.createCollection('activity'),
+  db.createCollection('track'),
+  db.createCollection('comment'),
+]);
 
 // print('indexing post collection...');
-db.post.createIndex({ uId: 1 });
-db.post.createIndex({ uId: 1, 'pl.id': 1 }, { sparse: true });
-db.post.createIndex({ 'pl.id': 1 }, { sparse: true });
-db.post.createIndex({ order: 1 }, { sparse: true });
-db.post.createIndex({ eId: 1 });
-db.post.createIndex({ lov: 1 }, { sparse: true });
-db.post.createIndex({ 'repost.pId': 1 }, { sparse: true });
-db.post.createIndex({ 'repost.uId': 1 }, { sparse: true });
+await db.collection('post').createIndex({ uId: 1 });
+await db
+  .collection('post')
+  .createIndex({ uId: 1, 'pl.id': 1 }, { sparse: true });
+await db.collection('post').createIndex({ 'pl.id': 1 }, { sparse: true });
+await db.collection('post').createIndex({ order: 1 }, { sparse: true });
+await db.collection('post').createIndex({ eId: 1 });
+await db.collection('post').createIndex({ lov: 1 }, { sparse: true });
+await db.collection('post').createIndex({ 'repost.pId': 1 }, { sparse: true });
+await db.collection('post').createIndex({ 'repost.uId': 1 }, { sparse: true });
 
 // print('indexing follow collection...');
-db.follow.createIndex({ uId: 1 });
-db.follow.createIndex({ tId: 1 });
+await db.collection('follow').createIndex({ uId: 1 });
+await db.collection('follow').createIndex({ tId: 1 });
 
 // print('indexing user collection...');
-db.user.createIndex({ email: 1 });
-db.user.createIndex({ handle: 1 }, { sparse: true });
-db.user.createIndex({ fbId: 1 }, { sparse: true });
-db.user.createIndex({ n: 1 }, { sparse: true });
-db.user.createIndex({ 'pref.pendEN': 1 }, { sparse: true });
-db.user.createIndex({ 'pref.nextEN': 1 }, { sparse: true });
-db.user.createIndex({ 'sp.id': 1 }, { sparse: true }); // spotify id
+await db.collection('user').createIndex({ email: 1 });
+await db.collection('user').createIndex({ handle: 1 }, { sparse: true });
+await db.collection('user').createIndex({ fbId: 1 }, { sparse: true });
+await db.collection('user').createIndex({ n: 1 }, { sparse: true });
+await db.collection('user').createIndex({ 'pref.pendEN': 1 }, { sparse: true });
+await db.collection('user').createIndex({ 'pref.nextEN': 1 }, { sparse: true });
+await db.collection('user').createIndex({ 'sp.id': 1 }, { sparse: true }); // spotify id
 
 // print('removing legacy fields on user collection...');
-db.user.dropIndex({ apTok: 1 });
-db.user.updateMany({}, { $unset: { apTok: 1 } });
+await db.collection('user').dropIndex({ apTok: 1 });
+await db.collection('user').updateMany({}, { $unset: { apTok: 1 } });
 
 // print('indexing activity collection...');
-db.activity.createIndex({ id: 1 }, { sparse: true }); /*poster.id*/
-db.activity.createIndex({ 'like.id': 1 }, { sparse: true });
-db.activity.createIndex({ 'like.pId': 1 }, { sparse: true });
+await db
+  .collection('activity')
+  .createIndex({ id: 1 }, { sparse: true }); /*poster.id*/
+await db.collection('activity').createIndex({ 'like.id': 1 }, { sparse: true });
+await db
+  .collection('activity')
+  .createIndex({ 'like.pId': 1 }, { sparse: true });
 
 // print('indexing track collection...');
-db.track.createIndex({ eId: 1 });
-db.track.createIndex({ score: 1 });
+await db.collection('track').createIndex({ eId: 1 });
+await db.collection('track').createIndex({ score: 1 });
 
 // print('indexing comment collection...');
-db.comment.createIndex({ pId: 1 });
+await db.collection('comment').createIndex({ pId: 1 });
 
 // print('indexing notif collection...');
-db.notif.createIndex({ uId: 1 });
+await db.collection('notif').createIndex({ uId: 1 });
 
 print('done! :-)');

--- a/config/initdb.js
+++ b/config/initdb.js
@@ -5,18 +5,22 @@
 //print("connecting to openwhyd_data database...");
 //db = db.getSiblingDB("openwhyd_data"); //connect("localhost:27017/whyd_music");
 
+const tolerateError = (name) => (err) => {
+  if (!err.message.includes(name)) throw err;
+};
+
 print('creating openwhyd collections...');
 await Promise.all([
-  db.createCollection('config'),
-  db.createCollection('email'),
-  db.createCollection('invite'),
-  db.createCollection('notif'),
-  db.createCollection('user'),
-  db.createCollection('follow'),
-  db.createCollection('post'),
-  db.createCollection('activity'),
-  db.createCollection('track'),
-  db.createCollection('comment'),
+  db.createCollection('config').catch(tolerateError('already exists')),
+  db.createCollection('email').catch(tolerateError('already exists')),
+  db.createCollection('invite').catch(tolerateError('already exists')),
+  db.createCollection('notif').catch(tolerateError('already exists')),
+  db.createCollection('user').catch(tolerateError('already exists')),
+  db.createCollection('follow').catch(tolerateError('already exists')),
+  db.createCollection('post').catch(tolerateError('already exists')),
+  db.createCollection('activity').catch(tolerateError('already exists')),
+  db.createCollection('track').catch(tolerateError('already exists')),
+  db.createCollection('comment').catch(tolerateError('already exists')),
 ]);
 
 // print('indexing post collection...');
@@ -45,7 +49,10 @@ await db.collection('user').createIndex({ 'pref.nextEN': 1 }, { sparse: true });
 await db.collection('user').createIndex({ 'sp.id': 1 }, { sparse: true }); // spotify id
 
 // print('removing legacy fields on user collection...');
-await db.collection('user').dropIndex({ apTok: 1 });
+await db
+  .collection('user')
+  .dropIndex({ apTok: 1 })
+  .catch(tolerateError("can't find index"));
 await db.collection('user').updateMany({}, { $unset: { apTok: 1 } });
 
 // print('indexing activity collection...');

--- a/config/initdb_testing.js
+++ b/config/initdb_testing.js
@@ -1,13 +1,12 @@
 /* globals db, ObjectId */
 
-// Usage: this file should be run by runShellScript() or by mongo's CLI:
-// $ mongo openwhyd_data initdb_testing.js
+// Usage: this file should be run by mongodb-shell-runner.js, on startup
 
 //db = db.getSiblingDB("openwhyd_data"); //connect("localhost:27017/whyd_music");
 
 print('upserting openwhyd testing users ...');
 
-db.user.updateOne(
+await db.collection('user').updateOne(
   { _id: ObjectId('000000000000000000000001') },
   {
     $set: {
@@ -25,7 +24,7 @@ db.user.updateOne(
   { upsert: true },
 );
 
-db.user.updateOne(
+await db.collection('user').updateOne(
   { _id: ObjectId('000000000000000000000002') },
   {
     $set: {


### PR DESCRIPTION
## What does this PR do / solve?

Db init script can fail randomly, e.g. 

```
web_1    | [db] Applying db init script: ./config/initdb.js ...
web_1    | node:internal/process/promises:246
web_1    |           triggerUncaughtException(err, true /* fromPromise */);
web_1    |           ^
web_1    | 
web_1    | [UnhandledPromiseRejection: This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason "TypeError: Cannot read properties of undefined (reading 'createIndex')".] {
web_1    |   code: 'ERR_UNHANDLED_REJECTION'
web_1    | }
```

cf https://github.com/openwhyd/openwhyd/actions/runs/5713134067/job/15477946339#step:7:11

## Overview of changes

Make the following commit work: [fix: simplify mongodb-shell-runner.js](https://github.com/openwhyd/openwhyd/commit/977a5ff388f24b3115a89d58811f12d483073129), by making db init scripts explicitly asynchronous => we move away from mongosh's script language.

## References

- [VM (executing JavaScript) | Node.js v20.5.0 Documentation](https://nodejs.org/api/vm.html#timeout-interactions-with-asynchronous-tasks-and-promises)