### PR TITLE
fix(api): report errors properly on post/comment APIs

### DIFF
--- a/app/controllers/api/post.js
+++ b/app/controllers/api/post.js
@@ -282,7 +282,7 @@ exports.handleRequest = function (request, reqParams, response, features) {
       res,
       null,
       args || { 'content-type': 'application/json' },
-      (res || {}).error ? 400 : 200,
+      (res || {}).error ? 400 : 200, // note: it would be better to return a 404 when post is not found
     );
   }
 

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -176,7 +176,7 @@ exports.delete = function (p, cb) {
     q,
     combineResult(function (comment) {
       if (!comment || comment.error) {
-        cb && cb({ error: comment ? comment.error : 'comment not found' }); // TODO: return 404
+        cb && cb({ error: comment ? comment.error : 'comment not found' });
         return;
       }
       postModel.fetchPostById(

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -174,9 +174,9 @@ exports.delete = function (p, cb) {
   var q = { _id: mongodb.ObjectId('' + p._id) };
   getCol().findOne(
     q,
-    combineResult(function (comment = { error: 'comment not found' }) {
-      if (comment.error) {
-        cb && cb(comment);
+    combineResult(function (comment) {
+      if (!comment || comment.error) {
+        cb && cb({ error: comment ? comment.error : 'comment not found' }); // TODO: return 404
         return;
       }
       postModel.fetchPostById(

--- a/app/models/comment.js
+++ b/app/models/comment.js
@@ -179,20 +179,17 @@ exports.delete = function (p, cb) {
         cb && cb({ error: comment ? comment.error : 'comment not found' });
         return;
       }
-      postModel.fetchPostById(
-        comment.pId,
-        (post = { error: 'post not found' }) => {
-          if (post.error) {
-            cb && cb(post);
-            return;
-          }
-          if (p.uId != post.uId && comment.uId != p.uId) {
-            cb && cb({ error: 'you are not allowed to delete this comment' });
-            return;
-          }
-          getCol().deleteOne(q, combineResult(cb));
-        },
-      );
+      postModel.fetchPostById(comment.pId, (post) => {
+        if (!post || post.error) {
+          cb && cb({ error: post ? post.error : 'post not found' });
+          return;
+        }
+        if (p.uId != post.uId && comment.uId != p.uId) {
+          cb && cb({ error: 'you are not allowed to delete this comment' });
+          return;
+        }
+        getCol().deleteOne(q, combineResult(cb));
+      });
     }),
   );
 };

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -218,6 +218,9 @@ class OpenwhydTestEnv {
   async dumpCollection(collection) {
     return await dumpMongoCollection(this.getEnv().MONGODB_URL, collection);
   }
+  async insertTestData(docsPerCollection) {
+    return await insertTestData(this.getEnv().MONGODB_URL, docsPerCollection);
+  }
 }
 
 module.exports = {

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const util = require('util');
 const request = require('request');
-const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
+const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 
 const { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
 const api = require('../api-client.js');
@@ -392,5 +392,31 @@ describe(`post api`, function () {
     const resBody = JSON.parse(res.body);
 
     assert.deepEqual(resBody, { error: 'comment not found' });
+  });
+
+  it('should fail to delete a comment on a post that does not exist', async function () {
+    const postId = '000000000000000000000009';
+    const commentId = '000000000000000000000010';
+    await openwhyd.insertTestData({
+      comment: [{ _id: ObjectId(commentId), pId: postId }],
+    });
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'deleteComment',
+            pId: postId,
+            _id: commentId,
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body }),
+      ),
+    );
+    const resBody = JSON.parse(res.body);
+    assert.deepEqual(resBody, { error: 'post not found' });
   });
 });

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -371,4 +371,26 @@ describe(`post api`, function () {
     assert.equal(postedTrack.repost.uId, ADMIN_USER.id);
     assert.equal(postedTrack.repost.uNm, ADMIN_USER.name);
   });
+
+  it('should fail to delete a comment that does not exist', async function () {
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'deleteComment',
+            pId: '000000000000000000000009',
+            _id: '000000000000000000000009',
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body }),
+      ),
+    );
+
+    const resBody = JSON.parse(res.body);
+
+    assert.deepEqual(resBody, { error: 'comment not found' });
+  });
 });

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -482,4 +482,31 @@ describe(`post api`, function () {
     const resBody = JSON.parse(res.body);
     assert.deepEqual(resBody, { acknowledged: true, deletedCount: 1 });
   });
+
+  it("should allow post's author to delete anyone's comment on that post", async function () {
+    const postId = '000000000000000000000009';
+    const commentId = '000000000000000000000010';
+    await openwhyd.insertTestData({
+      post: [{ _id: ObjectId(postId), uId: loggedUser.id }],
+      comment: [{ _id: ObjectId(commentId), pId: postId, uId: otherUser.id }],
+    });
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'deleteComment',
+            pId: postId,
+            _id: commentId,
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body }),
+      ),
+    );
+    const resBody = JSON.parse(res.body);
+    assert.deepEqual(resBody, { acknowledged: true, deletedCount: 1 });
+  });
 });

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -3,7 +3,12 @@ const util = require('util');
 const request = require('request');
 const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 
-const { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
+const {
+  ADMIN_USER,
+  cleanup,
+  URL_PREFIX,
+  DUMMY_USER,
+} = require('../fixtures.js');
 const api = require('../api-client.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
@@ -418,5 +423,34 @@ describe(`post api`, function () {
     );
     const resBody = JSON.parse(res.body);
     assert.deepEqual(resBody, { error: 'post not found' });
+  });
+
+  it("should fail to delete someone else's comment", async function () {
+    const postId = '000000000000000000000009';
+    const commentId = '000000000000000000000010';
+    await openwhyd.insertTestData({
+      post: [{ _id: ObjectId(postId) }],
+      comment: [{ _id: ObjectId(commentId), pId: postId, uId: DUMMY_USER._id }],
+    });
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'deleteComment',
+            pId: postId,
+            _id: commentId,
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body }),
+      ),
+    );
+    const resBody = JSON.parse(res.body);
+    assert.deepEqual(resBody, {
+      error: 'you are not allowed to delete this comment',
+    });
   });
 });

--- a/test/integration/post.api.tests.js
+++ b/test/integration/post.api.tests.js
@@ -509,4 +509,32 @@ describe(`post api`, function () {
     const resBody = JSON.parse(res.body);
     assert.deepEqual(resBody, { acknowledged: true, deletedCount: 1 });
   });
+
+  it("should post a comment on anyone's post", async function () {
+    const postId = '000000000000000000000009';
+    const commentText = '"hello world"';
+    await openwhyd.insertTestData({
+      post: [{ _id: ObjectId(postId) }],
+    });
+
+    const res = await new Promise((resolve, reject) =>
+      request.post(
+        {
+          jar,
+          form: {
+            action: 'addComment',
+            pId: postId,
+            text: commentText,
+          },
+          url: `${URL_PREFIX}/api/post`,
+        },
+        (error, response, body) =>
+          error ? reject(error) : resolve({ response, body }),
+      ),
+    );
+    const resBody = JSON.parse(res.body);
+    assert(resBody?._id, '_id should be provided in response');
+    assert.equal(typeof resBody._id, 'string');
+    assert.notEqual(resBody._id, '', '_id should not be empty');
+  });
 });


### PR DESCRIPTION
## What does this PR do / solve?

Occasional error in production: `Cannot read properties of null (reading 'error')`

<img width="751" alt="image" src="https://github.com/openwhyd/openwhyd/assets/531781/c0c0ba07-9243-4fd8-a2bf-7f21bbe01b16">

cf https://app.datadoghq.com/logs?query=host%3Aopenwhyd-2gb%20service%3Aopenwhyd_pm2%20filename%3Aapp-error.log%20&cols=host%2Cservice&context_event=AYmtODT2AAAb8z_CnuWguwAA&event=AgAAAYmtOCpeZSiWGQAAAAAAAAAYAAAAAEFZbXRPRFQyQUFBYjh6X0NudVdndXdBQQAAACQAAAAAMDE4OWFkODQtMWQzZC00MzE4LTgwNmYtZGQzZGMyNjU3MDIw&index=%2A&messageDisplay=inline&saved-view-id=1990243&stream_sort=time%2Cdesc&to_event=AgAAAYmth11Ypxv4tgAAAAAAAAAYAAAAAEFZbXRoMlptQUFCaXJBNVU4QXVicVFBQQAAACQAAAAAMDE4OWFkODktM2FiYy00YjNkLTkyNzEtNTljZTI5YTU5ZmIz&viz=&from_ts=1690827986558&to_ts=1690833476952&live=false

## Overview of changes

- report error when trying to delete a comment that does not exist
- report error when trying to delete a comment associated to a post that does not exist
- add API/integration tests

## How to test this PR?

```sh
$ docker compose up mongo -d
$ START_WITH_ENV_FILE='./env-vars-testing.conf' npx mocha test/integration/post.api.tests.js
$ docker compose down
```