### PR TITLE
fix(#649): validate http parameters on user library pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,7 +182,7 @@ jobs:
     runs-on: ubuntu-20.04
     services:
       mongodb:
-        image: docker://mongo:3.6
+        image: docker://mongo:3.6@sha256:146c1fd999a660e697aac40bc6da842b005c7868232eb0b7d8996c8f3545b05d
         ports:
           - 27117:27017
     steps:
@@ -190,8 +190,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: 'npm'
-      - run: npm ci --prefer-offline --no-audit
+      - run: npm ci
       - name: API tests
         run: npm run test:integration:api:coverage
         # TODO: find a way to run other integration tests too

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
         run: docker-compose exec -T web npm run test:unit
       - name: Run API tests
         env:
-          MONGODB_URL: mongodb://mongo:27117/openwhyd_test
+          MONGODB_URL: mongodb://mongo:27017/openwhyd_test
         run: docker-compose exec --env MONGODB_URL -T web npm run test:integration
       - name: Logs from docker-compose
         if: ${{ always() }} # this step is useful to troubleshoot the execution of openwhyd when tests fail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,8 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-      - run: npm ci
+          cache: 'npm'
+      - run: npm ci --prefer-offline --no-audit
       - name: API tests
         run: npm run test:integration:api:coverage
         # TODO: find a way to run other integration tests too

--- a/app/controllers/LibUser.js
+++ b/app/controllers/LibUser.js
@@ -1,3 +1,13 @@
+//@ts-check
+
+// WIP: Type definitions are incomplete and some may be wrong
+/** @typedef {{ loggedUser: any, pageUrl?: string }} RequestContext */
+/** @typedef {{ uid?: string, user?: { lnk: string, pl: unknown } }} RequestedUserData */
+/** @typedef {{ playlistId?: string }} RequestedPlaylistData */
+/** @typedef {{ after?: number | string, limit?: number | string }} PaginationParameters */
+/** @typedef {{ bodyClass?: string, format?: string, displayPlaylistName?: boolean, embedW?: unknown, content?: string, callback?: string }} RenderingAttributes */
+/** @typedef { RequestContext & RequestedUserData & RequestedPlaylistData & PaginationParameters & RenderingAttributes } FetchAndRenderOptions */
+
 /**
  * LibUser class
  * fetchs and renders a user's library
@@ -68,6 +78,7 @@ function generateMixpanelCode(options) {
 
 var bareFormats = new Set(['json', 'links']);
 
+/** @param {FetchAndRenderOptions} options */
 function fetchAndRender(options, callback) {
   options.bodyClass = '';
 
@@ -101,7 +112,7 @@ function populatePaginationParameters(options) {
     limit: options.limit,
   };
   if (options.embedW)
-    options.fetchParams.limit = config.nbTracksPerPlaylistEmbed;
+    options.fetchParams.limit = process.appParams.nbTracksPerPlaylistEmbed;
   else if (options.limit && typeof options.limit !== 'number') {
     if (typeof options.limit === 'string')
       options.fetchParams.limit = parseInt(options.limit);
@@ -180,6 +191,7 @@ function renderResponse(feed, options, lib, user) {
     );
 }
 
+/** @param {{ options: FetchAndRenderOptions, render: (unknown) => void }} lib */
 async function renderUserLibrary(lib, user) {
   var options = lib.options;
 

--- a/app/controllers/LibUserProfile.js
+++ b/app/controllers/LibUserProfile.js
@@ -191,9 +191,7 @@ exports.fetchAndRender = function (options, callback) {
       fields: { _id: 0, uId: 1 },
       skip: Number(options.after || 0),
     };
-    console.warn('fetching subscribers', { params });
     followModel.fetch({ tId: options.user.id }, params, function (subscr) {
-      console.warn('fetching subscribers=>', { subscr });
       if (subscr.length > MAX_SUBSCRIPTIONS) {
         const lastPid = params.skip + MAX_SUBSCRIPTIONS;
         postsTemplate.populateNextPageUrl(options, lastPid);

--- a/app/controllers/LibUserProfile.js
+++ b/app/controllers/LibUserProfile.js
@@ -111,6 +111,7 @@ function populateUsers(subscr, options, cb) {
   );
 }
 
+/** @param {FetchAndRenderOptions} options */
 exports.fetchAndRender = function (options, callback) {
   options.bodyClass += ' userProfileV2';
   options.nbPlaylists = (options.user.pl || []).length;
@@ -190,7 +191,9 @@ exports.fetchAndRender = function (options, callback) {
       fields: { _id: 0, uId: 1 },
       skip: Number(options.after || 0),
     };
+    console.warn('fetching subscribers', { params });
     followModel.fetch({ tId: options.user.id }, params, function (subscr) {
+      console.warn('fetching subscribers=>', { subscr });
       if (subscr.length > MAX_SUBSCRIPTIONS) {
         const lastPid = params.skip + MAX_SUBSCRIPTIONS;
         postsTemplate.populateNextPageUrl(options, lastPid);

--- a/app/controllers/userLibrary.js
+++ b/app/controllers/userLibrary.js
@@ -1,3 +1,5 @@
+//@ts-check
+
 /**
  * userLibrary controller
  * shows an organized view of posts (user's and friends' library)
@@ -37,6 +39,7 @@ var paramsToInclude = [
 function LibraryController(reqParams, render) {
   reqParams = reqParams || {};
   this.render = render;
+  /** @type import('./LibUser.js').FetchAndRenderOptions */
   this.options = {
     loggedUser: reqParams.loggedUser || {} /*,
 		after: reqParams.after,

--- a/app/controllers/userLibrary.js
+++ b/app/controllers/userLibrary.js
@@ -41,16 +41,7 @@ function LibraryController(reqParams, render) {
   this.render = render;
   /** @type import('./LibUser.js').FetchAndRenderOptions */
   this.options = {
-    loggedUser: reqParams.loggedUser || {} /*,
-		after: reqParams.after,
-		before: reqParams.before,
-		limit: reqParams.limit,
-		playlistId: reqParams.playlistId,
-		showPlaylists: reqParams.showPlaylists,
-		showLikes: reqParams.showLikes,
-		embedW: reqParams.embedW,
-		format: reqParams.format,
-		pageUrl: reqParams.pageUrl*/,
+    loggedUser: reqParams.loggedUser || {},
   };
   for (let i in paramsToInclude)
     this.options[paramsToInclude[i]] = reqParams[paramsToInclude[i]];

--- a/app/controllers/userLibrary.js
+++ b/app/controllers/userLibrary.js
@@ -43,8 +43,12 @@ function LibraryController(reqParams, render) {
   this.options = {
     loggedUser: reqParams.loggedUser || {},
   };
-  for (let i in paramsToInclude)
-    this.options[paramsToInclude[i]] = reqParams[paramsToInclude[i]];
+  for (const paramName of paramsToInclude) {
+    const value = reqParams[paramName];
+    if (typeof value === 'object')
+      throw new Error(`invalid parameter value: ${paramName}`);
+    this.options[paramName] = value;
+  }
   if (typeof this.options.limit == 'string')
     this.options.limit = parseInt(this.options.limit);
   if (this.options.callback) this.options.format = 'json';
@@ -137,7 +141,13 @@ exports.controller = function (request, reqParams, response) {
     else response.legacyRender(data.error);
   }
 
-  var lib = new LibraryController(reqParams, render);
+  let lib;
+  try {
+    lib = new LibraryController(reqParams, render);
+  } catch (err) {
+    response.badRequest({ error: err.message });
+    return;
+  }
 
   function redirectTo(path) {
     var paramsObj = {},

--- a/app/models/logging.js
+++ b/app/models/logging.js
@@ -286,7 +286,10 @@ http.ServerResponse.prototype.temporaryRedirect = function (_url, _reqParams) {
 };
 
 http.ServerResponse.prototype.badRequest = function (error) {
-  this.status(400).send(error ? '' + error : 'BAD REQUEST');
+  this.status(400).send(
+    (typeof error === 'object' ? JSON.stringify(error) : error) ??
+      'BAD REQUEST',
+  );
 };
 
 http.ServerResponse.prototype.forbidden = function (error) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,14 @@
 version: '3'
 services:
   mongo:
-    image: mongo:3.6
-    command: mongod --port 27117
+    image: mongo:3.6@sha256:146c1fd999a660e697aac40bc6da842b005c7868232eb0b7d8996c8f3545b05d
+    command: mongod --port 27017
     volumes:
       - target: /data
         type: tmpfs
     ports:
-      - '27117:27117'
+      - '27117:27017'
+    restart: 'always'
 
   web:
     restart: 'always'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,10 @@ services:
     image: mongo:3.6
     command: mongod --port 27117
     volumes:
-      - /data # Data Persistance
+      - target: /data
+        type: tmpfs
     ports:
       - '27117:27117'
-    logging:
-      driver: none
 
   web:
     restart: 'always'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,6 @@ services:
     environment:
       - DISABLE_DATADOG=true
       - MONGODB_HOST=mongo
-      - MONGODB_PORT=27117
+      - MONGODB_PORT=27017
       - ALGOLIA_APP_ID
       - ALGOLIA_API_KEY

--- a/test/integration/user.api.tests.js
+++ b/test/integration/user.api.tests.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const util = require('util');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
 const { DUMMY_USER, cleanup } = require('../fixtures.js');
@@ -53,5 +54,16 @@ describe('user api', () => {
         });
       });
     });
+  });
+
+  it('should allow just one value for the `after` parameter, when fetching subscribers', async () => {
+    const url =
+      '/dummy/subscribers?after=50&after=100&wholePage=true&wholePage=true';
+    const { body, ...res } = await util.promisify(api.get)({}, url);
+    assert.equal(res.response.statusCode, 200);
+    assert.equal(
+      body.error,
+      'invalid parameter: after should be a numeric value',
+    );
   });
 });

--- a/test/integration/user.api.tests.js
+++ b/test/integration/user.api.tests.js
@@ -57,13 +57,9 @@ describe('user api', () => {
   });
 
   it('should allow just one value for the `after` parameter, when fetching subscribers', async () => {
-    const url =
-      '/dummy/subscribers?after=50&after=100&wholePage=true&wholePage=true';
+    const url = '/dummy/subscribers?after=50&after=100';
     const { body, ...res } = await util.promisify(api.get)({}, url);
-    assert.equal(res.response.statusCode, 200);
-    assert.equal(
-      body.error,
-      'invalid parameter: after should be a numeric value',
-    );
+    assert.equal(res.response.statusCode, 400);
+    assert.equal(body.error, 'invalid parameter value: after');
   });
 });


### PR DESCRIPTION
Fixes #649.

## What does this PR do / solve?

Openwhyd's server logs `Skip value must be non-negative` errors from MongoDB, when the `after` GET/query parameter is provided twice to a user profile endpoint.

Why:
- when a GET/query parameter is provided twice, it's converted into an array of values
- converting an array to `Number` results in `NaN`, which is seen by MongoDB as a negative number.

## Overview of changes

- validate the `after` parameter (and others) so that duplicated parameters result in an error message
- ensure that behavior using an automated test
- [bonus] also fix `error response from daemon: configured logging driver does not support reading` when trying to read logs from mongodb container, by enabling logs and using a `tmpfs` volume
- [bonus] also fixes a bug regarding the max number of posts to include in an embedded player, see https://github.com/openwhyd/openwhyd/pull/650/files#diff-6026be8410fe0718c82dc832476e82796921efb23743767e0247f3653ae62a9fR115
- [bonus] to ease local reproduction of such issues:
  - improve the `import` script so that subscribers are also imported
  - fix the configuration of the mongodb docker container, to get local env closer to CI env
