### PR TITLE
test: upload playlist images

### DIFF
--- a/app/controllers/testing/reset.js
+++ b/app/controllers/testing/reset.js
@@ -1,5 +1,8 @@
 // A private controller for Cypress to be able to reset the database between tests
 
+const path = require('path');
+const { readdirSync, rmSync } = require('fs');
+
 const mongodb = require('../../models/mongodb.js');
 
 exports.controller = async function (request, getParams, response) {
@@ -12,8 +15,17 @@ exports.controller = async function (request, getParams, response) {
     return response.forbidden(new Error('allowed on test database only'));
   }
   try {
+    // reinitialize database state
     await mongodb.clearCollections();
     await mongodb.initCollections({ addTestData: true });
+
+    // delete uploaded files
+    const appDir = process.cwd();
+    ['uAvatarImg', 'uCoverImg', 'upload_data'].forEach((subDir) => {
+      const dir = path.join(appDir, subDir);
+      readdirSync(dir).forEach((file) => rmSync(`${dir}/${file}`));
+    });
+
     response.renderJSON({ ok: true });
   } catch (err) {
     response.renderJSON({ error: err.message });

--- a/app/controllers/testing/reset.js
+++ b/app/controllers/testing/reset.js
@@ -21,10 +21,15 @@ exports.controller = async function (request, getParams, response) {
 
     // delete uploaded files
     const appDir = process.cwd();
-    ['uAvatarImg', 'uCoverImg', 'upload_data'].forEach((subDir) => {
-      const dir = path.join(appDir, subDir);
-      readdirSync(dir).forEach((file) => rmSync(`${dir}/${file}`));
-    });
+    ['uAvatarImg', 'uCoverImg', 'uPlaylistImg', 'upload_data'].forEach(
+      (subDir) => {
+        const dir = path.join(appDir, subDir);
+        readdirSync(dir).forEach((file) => {
+          console.warn(`reset.controller deleting ${dir}/${file}`);
+          rmSync(`${dir}/${file}`);
+        });
+      },
+    );
 
     response.renderJSON({ ok: true });
   } catch (err) {

--- a/cypress/e2e/upload.spec.ts
+++ b/cypress/e2e/upload.spec.ts
@@ -50,10 +50,7 @@ context('upload', () => {
 
     // expect the playlist to have a default image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
-    cy.request({
-      url: `/img/playlist/${userId}_0?remoteOnly=1`,
-      failOnStatusCode: false,
-    }).should('have.property', 'status', 404);
+    playlistShouldHaveNoImage({ userId, playlistId: 1 });
 
     // create a playlist with custom image
     cy.visit(`/u/${userId}/playlists`); // user's playlists page
@@ -65,10 +62,7 @@ context('upload', () => {
 
     // expect the playlist to have a custom image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
-    cy.request({
-      url: `/img/playlist/${userId}_1?remoteOnly=1`,
-      retryOnStatusCodeFailure: true,
-    }).should('have.property', 'status', 200);
+    playlistShouldHaveCustomImage({ userId, playlistId: 1 });
 
     cy.visit(`/u/${userId}/playlists`); // user's playlists page
   });
@@ -82,10 +76,7 @@ context('upload', () => {
 
     // expect the playlist to have a default image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
-    cy.request({
-      url: `/img/playlist/${userId}_0?remoteOnly=1`,
-      failOnStatusCode: false,
-    }).should('have.property', 'status', 404);
+    playlistShouldHaveNoImage({ userId, playlistId: 0 });
 
     // set the playlist's image
     cy.wait(1000);
@@ -99,9 +90,24 @@ context('upload', () => {
 
     // expect the playlist to have a custom image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
-    cy.request({
-      url: `/img/playlist/${userId}_0?remoteOnly=1`,
-      retryOnStatusCodeFailure: true,
-    }).should('have.property', 'status', 200);
+    playlistShouldHaveCustomImage({ userId, playlistId: 0 });
   });
 });
+
+function playlistShouldHaveCustomImage({ userId, playlistId }) {
+  return cy
+    .request({
+      url: `/img/playlist/${userId}_${playlistId}?remoteOnly=1`,
+      retryOnStatusCodeFailure: true,
+    })
+    .should('have.property', 'status', 200);
+}
+
+function playlistShouldHaveNoImage({ userId, playlistId }) {
+  return cy
+    .request({
+      url: `/img/playlist/${userId}_${playlistId}?remoteOnly=1`,
+      failOnStatusCode: false,
+    })
+    .should('have.property', 'status', 404);
+}

--- a/cypress/e2e/upload.spec.ts
+++ b/cypress/e2e/upload.spec.ts
@@ -46,7 +46,7 @@ context('upload', () => {
     cy.visit(`/u/${userId}/playlists`); // user's playlists page
     cy.get('body').contains('+ New Playlist').click();
     cy.get('form[id="playlistForm"] input[name="name"]').type('playlist 1');
-    cy.get('body').contains('Save').scrollIntoView().click({ force: true });
+    cy.get('body').contains('Save').click();
 
     // expect the playlist to have a default image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
@@ -61,7 +61,7 @@ context('upload', () => {
     cy.get('form[id="playlistForm"] input[name="name"]').type('playlist 2');
     cy.get('body').contains('Add/set playlist cover image').click();
     cy.get('input[type="file"]').attachFile(SAMPLE_IMG_PATH); // to upload the file
-    cy.get('body').contains('Save').scrollIntoView().click({ force: true });
+    cy.get('body').contains('Save').click();
 
     // expect the playlist to have a custom image
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);

--- a/cypress/e2e/upload.spec.ts
+++ b/cypress/e2e/upload.spec.ts
@@ -67,7 +67,7 @@ context('upload', () => {
     cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
     cy.request({
       url: `/img/playlist/${userId}_1?remoteOnly=1`,
-      failOnStatusCode: false,
+      retryOnStatusCodeFailure: true,
     }).should('have.property', 'status', 200);
 
     cy.visit(`/u/${userId}/playlists`); // user's playlists page

--- a/cypress/e2e/upload.spec.ts
+++ b/cypress/e2e/upload.spec.ts
@@ -72,4 +72,36 @@ context('upload', () => {
 
     cy.visit(`/u/${userId}/playlists`); // user's playlists page
   });
+
+  it('should set the image of a new playlist', () => {
+    // create a playlist with default image
+    cy.visit(`/u/${userId}/playlists`); // user's playlists page
+    cy.get('body').contains('+ New Playlist').click();
+    cy.get('form[id="playlistForm"] input[name="name"]').type('playlist 1');
+    cy.get('body').contains('Save').click();
+
+    // expect the playlist to have a default image
+    cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
+    cy.request({
+      url: `/img/playlist/${userId}_0?remoteOnly=1`,
+      failOnStatusCode: false,
+    }).should('have.property', 'status', 404);
+
+    // set the playlist's image
+    cy.wait(1000);
+    cy.get('.btnEditPlaylist').contains('Edit').click();
+    cy.get('body')
+      .contains('Add/set playlist cover image')
+      .should('be.visible') // to wait for upload scripts to load and init propertly on the page
+      .click();
+    cy.get('input[type="file"]').attachFile(SAMPLE_IMG_PATH); // to upload the file
+    cy.get('body').contains('Save').click();
+
+    // expect the playlist to have a custom image
+    cy.url().should('match', /\/u\/.*\/playlist\/[0-9]+$/);
+    cy.request({
+      url: `/img/playlist/${userId}_0?remoteOnly=1`,
+      retryOnStatusCodeFailure: true,
+    }).should('have.property', 'status', 200);
+  });
 });


### PR DESCRIPTION
Adding e2e test related to the upload of playlist images, so we can prevent regressions while fixing some errors logged in datadog:

<img width="982" alt="image" src="https://github.com/openwhyd/openwhyd/assets/531781/e9c26688-8159-4335-8c2e-1a2228f2a303">
