### PR TITLE
fix(api): return 404 on missing images => stop logging errors

### DIFF
--- a/app/controllers/uploadedFile.js
+++ b/app/controllers/uploadedFile.js
@@ -114,22 +114,22 @@ exports.moveTo = function (filename, toPath, callback) {
 
 exports.controller = function (request, reqParams, response) {
   function renderNoImage() {
-    response.sendFile(NO_IMAGE_PATH);
+    response.status(404).sendFile(NO_IMAGE_PATH);
   }
 
   function renderFile(path, defaultImg) {
     response.sendFile('' + path, function (error) {
       if (!error) return;
-      console.trace(`renderFile error for ${path}:`, error);
       if (defaultImg) {
         const defaultImagePath =
           exports.config.whydPath + '/public' + defaultImg;
-        response.sendFile(defaultImagePath, (err) => {
+        response.status(404).sendFile(defaultImagePath, (err) => {
           if (!err) return;
-          console.trace(`renderFile error for ${defaultImagePath}:`, err);
           renderNoImage();
         });
-      } else renderNoImage();
+      } else {
+        renderNoImage();
+      }
     });
   }
 

--- a/test/api-client.js
+++ b/test/api-client.js
@@ -1,3 +1,4 @@
+const util = require('util');
 const assert = require('assert');
 const request = require('request'); // TODO: promisify it
 
@@ -123,6 +124,7 @@ exports.getUser = function (jar, body, callback) {
   });
 };
 
+/** Documentation: https://openwhyd.github.io/openwhyd/API.html#set-user-data */
 exports.setUser = function (jar, body, callback) {
   request.post(
     {
@@ -206,4 +208,17 @@ exports.getPlaylist = function (jar, plId, callback) {
 exports.getPlaylistTracks = function (jar, uId, plId, callback) {
   // TODO: define a version that accepts parameters (limit, after, before...)
   exports.get(jar, `/${uId}/playlist/${plId}?format=json`, callback);
+};
+
+/**
+ * Uploads an image.
+ * @param {*} jar
+ * @param {import('fs').ReadStream} dataStream - e.g. fs.createReadStream(__dirname + '/attachment1.jpg')
+ * @returns {{ mime: string, path: string, thumbs: Record<string, string> }} - e.g. { mime: 'image/jpeg', path: 'upload_data/aea7b2adefac48afaaa465c00_180x', thumbs: { '180x': 'upload_data/e645c9f60b93ddbecde73bc00_180x' } }
+ */
+exports.uploadImage = async function (jar, dataStream) {
+  const formData = { postImg: dataStream };
+  const url = `${URL_PREFIX}/upload`;
+  const res = await util.promisify(request.post)({ url, formData, jar });
+  return JSON.parse(res.body).postImg;
 };

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -46,11 +46,11 @@ describe('user api', function () {
       const tmpImageData = await fs.promises.readFile(`./${tmpImage.path}`);
       await util.promisify(api.setUser)(jar, { img: tmpImage.path });
 
-      // when they ask for their avatar URL
+      // when they ask for their avatar
       const url = `/uAvatarImg/${DUMMY_USER.id}`;
       const { body } = await util.promisify(api.getRaw)(jar, url);
 
-      // then they should be redirected to the final URL of that image
+      // then they should receive the image data
       assert.equal(body, tmpImageData.toString());
     });
 
@@ -68,11 +68,24 @@ describe('user api', function () {
       const url = res.body.img;
       assert(url.startsWith('/uAvatarImg/'));
 
-      // when they ask for their avatar URL
+      // when they ask for their avatar
       const { body } = await util.promisify(api.getRaw)(jar, url);
 
-      // then they should be redirected to the final URL of that image
+      // then they should receive the image data
       assert.equal(body, tmpImageData.toString());
+    });
+
+    it("should provide a default avatar for users that don't exist", async () => {
+      // when somebody asks for the avatar of a user that does not exist
+      const url = `/uAvatarImg/ababababababab`;
+      const { body } = await util.promisify(api.getRaw)(null, url);
+
+      // then they should receive a default avatar
+      const defaultAvatarData = await fs.promises.readFile(
+        `./public/images/blank_user.gif`,
+        'utf-8',
+      );
+      assert.equal(body, defaultAvatarData.toString());
     });
   });
 

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -75,10 +75,10 @@ describe('user api', function () {
       assert.equal(body, tmpImageData.toString());
     });
 
-    it("should provide a default avatar for users that don't exist", async () => {
+    it("should return a default avatar with a 404, for users that don't exist", async () => {
       // when somebody asks for the avatar of a user that does not exist
       const url = `/uAvatarImg/ababababababab`;
-      const { body } = await util.promisify(api.getRaw)(null, url);
+      const { body, response } = await util.promisify(api.getRaw)(null, url);
 
       // then they should receive a default avatar
       const defaultAvatarData = await fs.promises.readFile(
@@ -86,6 +86,7 @@ describe('user api', function () {
         'utf-8',
       );
       assert.equal(body, defaultAvatarData.toString());
+      assert.equal(response.statusCode, 404);
     });
   });
 

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -53,6 +53,27 @@ describe('user api', function () {
       // then they should be redirected to the final URL of that image
       assert.equal(body, tmpImageData.toString());
     });
+
+    it("should provide user's avatar thru /uAvatarImg/{path}", async () => {
+      // given a user with a custom avatar / user image
+      const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);
+      const tmpImage = await api.uploadImage(
+        jar,
+        fs.createReadStream('./public/press/images/adrien.png'),
+      );
+      const tmpImageData = await fs.promises.readFile(`./${tmpImage.path}`);
+      const res = await util.promisify(api.setUser)(jar, {
+        img: tmpImage.path,
+      });
+      const url = res.body.img;
+      assert(url.startsWith('/uAvatarImg/'));
+
+      // when they ask for their avatar URL
+      const { body } = await util.promisify(api.getRaw)(jar, url);
+
+      // then they should be redirected to the final URL of that image
+      assert.equal(body, tmpImageData.toString());
+    });
   });
 
   describe(`setting user data`, function () {

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -34,6 +34,15 @@ describe('user api', function () {
         });
       });
     });
+
+    it("should redirect to user's avatar URL", async () => {
+      // TODO: upload avatar for DUMMY_USER
+      const url = `/u/${DUMMY_USER.id}`;
+      const { body, ...res } = await util.promisify(api.get)(jar, url);
+      assert(!body.error);
+      assert.equal(res.response.statusCode, 307); // temporary redirect
+      assert.equal(res.headers?.Location, DUMMY_USER.img);
+    });
   });
 
   describe(`setting user data`, function () {


### PR DESCRIPTION
Motivation: reduce number of errors reported to Datadog => instead, notify clients when images are not found.

![image](https://github.com/openwhyd/openwhyd/assets/531781/c3fe791d-171e-47fe-bff2-473b35a80335)

cf https://app.datadoghq.com/logs?query=Error%20error%20-%22slow%20request%22%20-%22POST_NOT_FOUND%22%20-%22page%20404%22%20&agg_m=count&agg_t=count&cols=host%2Cservice&index=%2A&messageDisplay=inline&source=monitor_notif&stream_sort=desc&viz=stream&from_ts=1692101314785&to_ts=1692706114785&live=true
