### PR TITLE
fix(tests): better isolation of API tests => remove FIXMEs

### DIFF
--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -27,13 +27,6 @@ describe(`playlist api`, function () {
     await openwhyd.reset(); // to prevent side effects between test suites
   });
 
-  it('should impact the execution of following tests', async () => {
-    const client = connectToMongoDB(openwhyd.getEnv().MONGODB_URL);
-    const db = client.db();
-    await db.collection('user').deleteMany({});
-    client.close();
-  });
-
   it('should create a playlist', async function () {
     const playlistName = `playlist-${randomString()}`;
     const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);
@@ -55,13 +48,6 @@ describe(`playlist api`, function () {
     const { id, name } = JSON.parse(res.body);
     assert.equal(name, playlistName);
     assert.equal(id, 0);
-  });
-
-  it('should impact the execution of following tests (2)', async () => {
-    const client = connectToMongoDB(openwhyd.getEnv().MONGODB_URL);
-    const db = client.db();
-    await db.collection('user').deleteMany({});
-    client.close();
   });
 
   describe('`rename` action', () => {

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const util = require('util');
 const request = require('request');
 
-const { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
+const { DUMMY_USER, URL_PREFIX } = require('../fixtures.js');
 const api = require('../api-client.js');
 const { START_WITH_ENV_FILE } = process.env;
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
@@ -25,7 +25,7 @@ describe(`playlist api`, function () {
 
   it('should create a playlist', async function () {
     const playlistName = `playlist-${randomString()}`;
-    const { jar } = await util.promisify(api.loginAs)(ADMIN_USER); // FIXME: We are forced to use the ADMIN_USER, since DUMMY_USER is mutated by user.api.tests.js and the db cleanup seems to not work for the users collection. May be initdb_testing.js is not up to date with the current schema? => see #684.
+    const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);
     const res = await new Promise((resolve, reject) =>
       request.post(
         {

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -5,7 +5,11 @@ const request = require('request');
 const { DUMMY_USER, URL_PREFIX } = require('../fixtures.js');
 const api = require('../api-client.js');
 const { START_WITH_ENV_FILE } = process.env;
-const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
+const {
+  OpenwhydTestEnv,
+  ObjectId,
+  connectToMongoDB,
+} = require('../approval-tests-helpers.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
 describe(`playlist api`, function () {
@@ -21,6 +25,13 @@ describe(`playlist api`, function () {
 
   beforeEach(async () => {
     await openwhyd.reset(); // to prevent side effects between test suites
+  });
+
+  it('should impact the execution of following tests', async () => {
+    const client = connectToMongoDB(openwhyd.getEnv().MONGODB_URL);
+    const db = client.db();
+    await db.collection('user').deleteMany({});
+    client.close();
   });
 
   it('should create a playlist', async function () {
@@ -44,6 +55,13 @@ describe(`playlist api`, function () {
     const { id, name } = JSON.parse(res.body);
     assert.equal(name, playlistName);
     assert.equal(id, 0);
+  });
+
+  it('should impact the execution of following tests (2)', async () => {
+    const client = connectToMongoDB(openwhyd.getEnv().MONGODB_URL);
+    const db = client.db();
+    await db.collection('user').deleteMany({});
+    client.close();
   });
 
   describe('`rename` action', () => {

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -51,6 +51,7 @@ describe(`playlist api`, function () {
       // Given a user that has one playlist
       const userWithOnePlaylist = {
         ...DUMMY_USER,
+        pwd: DUMMY_USER.md5, // to allow login
         _id: ObjectId(DUMMY_USER.id),
         pl: [{ id: 0, name: 'old name' }],
       };

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -14,8 +14,8 @@ const api = require('../api-client.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
 describe(`post api`, function () {
-  const loggedUser = ADMIN_USER;
-  const otherUser = DUMMY_USER;
+  const loggedUser = DUMMY_USER;
+  const otherUser = ADMIN_USER;
   let post;
   let jar;
   const openwhyd = new OpenwhydTestEnv({
@@ -39,9 +39,6 @@ describe(`post api`, function () {
     };
 
     ({ jar } = await util.promisify(api.loginAs)(loggedUser));
-    /* FIXME: We are forced to use the ADMIN_USER, since DUMMY_USER is mutated by user.api.tests.js and the db cleanup seems to not work for the users collection.
-     * May be initdb_testing.js is not up to date with the current schema?
-     */
   });
 
   it("should return a 404 for post that doesn't exist", async () => {
@@ -111,8 +108,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.eId, post.eId);
     assert.equal(postedTrack.ctx, ctx);
     assert.equal(postedTrack.isNew, true);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.ok(postedTrack._id);
     assert.equal(postedTrack.pl, undefined);
   });
@@ -163,8 +160,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.pl.id, playlist.id);
     assert.equal(postedTrack.pl.name, playlist.name);
     assert.equal(postedTrack.text, description);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
   });
 
   it('should add a track to a new playlist', async function () {
@@ -194,8 +191,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.eId, post.eId);
     assert.equal(postedTrack.ctx, ctx);
     assert.equal(postedTrack.isNew, true);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.ok(postedTrack._id);
     assert.ok(postedTrack.pl.id);
     assert.equal(postedTrack.pl.name, newPlayListName);
@@ -241,8 +238,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.ctx, ctx);
     assert.equal(postedTrack.pl.name, newPlayListName);
     assert.equal(postedTrack.text, description);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
   });
 
   it('should re-add a track to a new playlist from the stream or from the Tracks in the user profile', async function () {
@@ -275,8 +272,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.eId, post.eId);
     assert.notEqual(postedTrack.pl.id, undefined);
     assert.equal(postedTrack.pl.name, newPlayListName);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.deepEqual(postedTrack.lov, []);
     assert.equal(postedTrack.text, '');
     assert.equal(postedTrack.nbP, 0);
@@ -285,8 +282,8 @@ describe(`post api`, function () {
     assert.notEqual(postedTrack._id, pId);
 
     assert.equal(postedTrack.repost.pId, pId);
-    assert.equal(postedTrack.repost.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.repost.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.repost.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.repost.uNm, DUMMY_USER.name);
   });
 
   it('should re-add a track into an existing playlist', async function () {
@@ -325,8 +322,8 @@ describe(`post api`, function () {
     assert.notEqual(postedTrack.pl.id, undefined);
     assert.equal(postedTrack.pl.id, playlist.id);
     assert.equal(postedTrack.pl.name, playlist.name);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.deepEqual(postedTrack.lov, []);
     assert.equal(postedTrack.text, '');
     assert.equal(postedTrack.nbP, 0);
@@ -335,8 +332,8 @@ describe(`post api`, function () {
     assert.notEqual(postedTrack._id, pId);
 
     assert.equal(postedTrack.repost.pId, pId);
-    assert.equal(postedTrack.repost.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.repost.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.repost.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.repost.uNm, DUMMY_USER.name);
   });
 
   it('should allow re-adding a track into another playlist', async function () {
@@ -374,8 +371,8 @@ describe(`post api`, function () {
     assert.equal(postedTrack.eId, post.eId);
     assert.ok(postedTrack.pl.id);
     assert.equal(postedTrack.pl.name, newPlaylistName);
-    assert.equal(postedTrack.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.deepEqual(postedTrack.lov, []);
     assert.equal(postedTrack.text, '');
     assert.equal(postedTrack.nbP, 0);
@@ -384,8 +381,8 @@ describe(`post api`, function () {
     assert.notEqual(postedTrack._id, pId);
 
     assert.equal(postedTrack.repost.pId, pId);
-    assert.equal(postedTrack.repost.uId, ADMIN_USER.id);
-    assert.equal(postedTrack.repost.uNm, ADMIN_USER.name);
+    assert.equal(postedTrack.repost.uId, DUMMY_USER.id);
+    assert.equal(postedTrack.repost.uNm, DUMMY_USER.name);
   });
 
   it('should fail to delete a comment that does not exist', async function () {

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -213,6 +213,9 @@ class OpenwhydTestEnv {
       ? this.serverProcess.env
       : process.env;
   }
+  getURL() {
+    return `http://localhost:${this.getEnv().WHYD_PORT}`;
+  }
   async dumpCollection(collection) {
     return await dumpMongoCollection(this.getEnv().MONGODB_URL, collection);
   }
@@ -220,8 +223,7 @@ class OpenwhydTestEnv {
     await resetTestDb.bind({ silent: true, env: this.getEnv() });
   }
   async refreshCache() {
-    const URL = `http://localhost:${this.getEnv().WHYD_PORT}`;
-    await refreshOpenwhydCache(URL);
+    await refreshOpenwhydCache(this.getURL());
   }
   async insertTestData(docsPerCollection) {
     await insertTestData(this.getEnv().MONGODB_URL, docsPerCollection);

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -173,7 +173,7 @@ const startOpenwhydServerWith = async (env) =>
     });
   });
 
-/** Refresh openwhyd's in-memory cache of users, e.g. to allow freshly added users to login. */
+/* refresh openwhyd's in-memory cache of users, to allow this user to login */
 async function refreshOpenwhydCache(urlPrefix) {
   const res = await promisify(request.post)(urlPrefix + '/testing/refresh');
   if (res.statusCode !== 200)
@@ -182,17 +182,16 @@ async function refreshOpenwhydCache(urlPrefix) {
 
 /** @param {{startWithEnv:unknown, port?: number | string | undefined}} options */
 async function startOpenwhydServer({ startWithEnv, port }) {
-  const env = {
-    ...(startWithEnv && (await loadEnvVars(startWithEnv))),
-    ...process.env, // allow overrides
-  };
-  await resetTestDb({ silent: true, env });
   if (port) {
-    return { URL: `http://localhost:${port}` };
+    const URL = `http://localhost:${port}`;
+    await refreshOpenwhydCache(URL);
+    return { URL };
   } else if (startWithEnv) {
+    const env = {
+      ...(await loadEnvVars(startWithEnv)),
+      ...process.env, // allow overrides
+    };
     return { ...(await startOpenwhydServerWith(env)), env }; // returns serverProcess instance with additional URL property (e.g. http://localhost:8080)
-  } else {
-    throw new Error('missing parameter: please provide startWithEnv or port');
   }
 }
 

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -220,7 +220,7 @@ class OpenwhydTestEnv {
     return await dumpMongoCollection(this.getEnv().MONGODB_URL, collection);
   }
   async reset() {
-    await resetTestDb.bind({ silent: true, env: this.getEnv() });
+    await resetTestDb({ silent: true, env: this.getEnv() });
   }
   async refreshCache() {
     await refreshOpenwhydCache(this.getURL());

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -173,7 +173,7 @@ const startOpenwhydServerWith = async (env) =>
     });
   });
 
-/* refresh openwhyd's in-memory cache of users, to allow this user to login */
+/** Refresh openwhyd's in-memory cache of users, e.g. to allow freshly added users to login. */
 async function refreshOpenwhydCache(urlPrefix) {
   const res = await promisify(request.post)(urlPrefix + '/testing/refresh');
   if (res.statusCode !== 200)
@@ -182,16 +182,17 @@ async function refreshOpenwhydCache(urlPrefix) {
 
 /** @param {{startWithEnv:unknown, port?: number | string | undefined}} options */
 async function startOpenwhydServer({ startWithEnv, port }) {
+  const env = {
+    ...(startWithEnv && (await loadEnvVars(startWithEnv))),
+    ...process.env, // allow overrides
+  };
+  await resetTestDb({ silent: true, env });
   if (port) {
-    const URL = `http://localhost:${port}`;
-    await refreshOpenwhydCache(URL);
-    return { URL };
+    return { URL: `http://localhost:${port}` };
   } else if (startWithEnv) {
-    const env = {
-      ...(await loadEnvVars(startWithEnv)),
-      ...process.env, // allow overrides
-    };
     return { ...(await startOpenwhydServerWith(env)), env }; // returns serverProcess instance with additional URL property (e.g. http://localhost:8080)
+  } else {
+    throw new Error('missing parameter: please provide startWithEnv or port');
   }
 }
 


### PR DESCRIPTION
Contributes to #684.

## What does this PR do / solve?

Several FIXME suggest that some integration tests that rely on DB state are not isolated and may fail when default test users are modified.

Reproduced: 
- See [fix test, to match with schema of posts](https://github.com/openwhyd/openwhyd/pull/680/commits/08c3b1de801e26d5cc176b299754201dc06b56d6), as seen in failing `post` API tests, only after they are run after `playlist` API tests (which mutate DUMMY_USER in the db). See logs: https://github.com/openwhyd/openwhyd/actions/runs/5998120167/job/16265796818?pr=680#step:6:172
- `posts` test pass when they are run alone
- when they are run after `playlist` tests, requests are rejected with `400` (badRequest) by `handleRequest` because `user` is an empty object. Hence the hypothesis of the test users not being properly reset between test suites.
- tests work as expected when skipping the `rename action` nested test suite from `test/api/playlist.api.tests.js` (which call `insertTestData` in the `user` collection, with an altered version of `DUMMY_USER`).

## Guidelines

In order to ensure isolation of tests, make sure to run `reset()` or `resetTestDb()` before the execution of every test.