### PR TITLE
fix(tests): improve test isolation and harmonize use of `OpenwhydTestEnv`

### DIFF
--- a/app/infrastructure/ImageStorage.js
+++ b/app/infrastructure/ImageStorage.js
@@ -49,12 +49,12 @@ class ImageStorage {
     const dir = path.join(appDir, directory);
     await Promise.all(
       (await fs.readdir(dir)).map((file) => {
-        console.warn(`reset.controller deleting ${dir}/${file}`);
         return fs.rm(`${dir}/${file}`);
       }),
     );
   }
 
+  /** FOR AUTOMATED TESTS ONLY */
   async deleteAllFiles() {
     await Promise.all(
       DIRECTORIES.map((directory) => this.deleteFiles(directory)),

--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -227,7 +227,10 @@ exports.initCollections = function ({ addTestData = false } = {}) {
   });
 };
 
-/** @param {{ mongoDbHost: string, mongoDbPort: string, mongoDbDatabase: string, mongoDbAuthUser?: string, mongoDbAuthPassword?: string }} connParams */
+/**
+ * @param {{ mongoDbHost: string, mongoDbPort: string, mongoDbDatabase: string, mongoDbAuthUser?: string, mongoDbAuthPassword?: string }} connParams
+ * @param {(err: null, db: mongodb.Db) => any} readyCallback
+ */
 exports.init = function (connParams, readyCallback) {
   isTesting = connParams.mongoDbDatabase === 'openwhyd_test';
   const dbName = connParams.mongoDbDatabase;
@@ -263,4 +266,5 @@ exports.init = function (connParams, readyCallback) {
 
   console.log(`[db] Successfully connected to ${publicURL}`);
   readyCallback.call(module.exports, null, exports._db);
+  return module.exports;
 };

--- a/app/nodejs-type-extensions.d.ts
+++ b/app/nodejs-type-extensions.d.ts
@@ -29,6 +29,7 @@ declare namespace NodeJS {
     NODE_ENV: 'development' | 'production' | undefined;
     MONGODB_URL: string | undefined;
     WHYD_PORT: string | undefined;
+    DEBUG: string | undefined;
   }
 
   export interface Process {

--- a/test/api-client.js
+++ b/test/api-client.js
@@ -2,7 +2,7 @@ const util = require('util');
 const assert = require('assert');
 const request = require('request'); // TODO: promisify it
 
-const { URL_PREFIX } = require('./fixtures.js');
+const URL_PREFIX = 'http://localhost:8080';
 
 const EXPECTED_RTK = 7; // cf app/controllers/invite.js
 

--- a/test/api/auth.api.tests.js
+++ b/test/api/auth.api.tests.js
@@ -2,7 +2,7 @@ const { promisify } = require('util');
 const assert = require('assert');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { ADMIN_USER, TEST_USER, cleanup } = require('../fixtures.js');
+const { ADMIN_USER, TEST_USER } = require('../fixtures.js');
 const apiClient = require('../api-client.js');
 
 const get = promisify(apiClient.get);
@@ -25,7 +25,7 @@ describe('auth api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true }));
+  before(async () => await openwhyd.reset());
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/auth.api.tests.js
+++ b/test/api/auth.api.tests.js
@@ -27,11 +27,14 @@ describe('auth api', function () {
 
   before(async () => {
     await openwhyd.setup();
-    await openwhyd.reset();
   });
 
   after(async () => {
     await openwhyd.release();
+  });
+
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
   });
 
   describe('login with email', () => {

--- a/test/api/auth.api.tests.js
+++ b/test/api/auth.api.tests.js
@@ -25,10 +25,9 @@ describe('auth api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset());
-
   before(async () => {
     await openwhyd.setup();
+    await openwhyd.reset();
   });
 
   after(async () => {

--- a/test/api/base.api.tests.js
+++ b/test/api/base.api.tests.js
@@ -17,7 +17,9 @@ describe('base api', function () {
     await openwhyd.release();
   });
 
-  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
+  });
 
   it("should return a 404 for URLs that don't exist", async () => {
     const { response } = await util.promisify(api.getRaw)(

--- a/test/api/base.api.tests.js
+++ b/test/api/base.api.tests.js
@@ -2,7 +2,6 @@ const assert = require('assert');
 const util = require('util');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { cleanup } = require('../fixtures.js');
 const api = require('../api-client.js');
 
 describe('base api', function () {
@@ -10,7 +9,7 @@ describe('base api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true })); // to prevent side effects between tests
+  before(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/base.api.tests.js
+++ b/test/api/base.api.tests.js
@@ -9,8 +9,6 @@ describe('base api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset()); // to prevent side effects between tests
-
   before(async () => {
     await openwhyd.setup();
   });
@@ -18,6 +16,8 @@ describe('base api', function () {
   after(async () => {
     await openwhyd.release();
   });
+
+  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   it("should return a 404 for URLs that don't exist", async () => {
     const { response } = await util.promisify(api.getRaw)(

--- a/test/api/data.api.tests.js
+++ b/test/api/data.api.tests.js
@@ -30,7 +30,7 @@ describe(`Data Export API`, function () {
 
   before(async () => {
     await openwhyd.setup();
-    async () => await openwhyd.reset(); // to prevent side effects between test suites
+    await openwhyd.reset(); // to prevent side effects between test suites
   });
 
   after(async () => {

--- a/test/api/data.api.tests.js
+++ b/test/api/data.api.tests.js
@@ -28,10 +28,9 @@ describe(`Data Export API`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset()); // to prevent side effects between tests
-
   before(async () => {
     await openwhyd.setup();
+    async () => await openwhyd.reset(); // to prevent side effects between test suites
   });
 
   after(async () => {

--- a/test/api/data.api.tests.js
+++ b/test/api/data.api.tests.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const request = require('request');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { URL_PREFIX, DUMMY_USER } = require('../fixtures.js');
+const { DUMMY_USER } = require('../fixtures.js');
 const api = require('../api-client.js');
 
 const reqGet = (url) =>
@@ -27,9 +27,11 @@ describe(`Data Export API`, function () {
   const openwhyd = new OpenwhydTestEnv({
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
+  let URL_PREFIX;
 
   before(async () => {
     await openwhyd.setup();
+    URL_PREFIX = openwhyd.getURL();
   });
 
   after(async () => {

--- a/test/api/data.api.tests.js
+++ b/test/api/data.api.tests.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const request = require('request');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { URL_PREFIX, DUMMY_USER, cleanup } = require('../fixtures.js');
+const { URL_PREFIX, DUMMY_USER } = require('../fixtures.js');
 const api = require('../api-client.js');
 
 const reqGet = (url) =>
@@ -28,7 +28,7 @@ describe(`Data Export API`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true })); // to prevent side effects between tests
+  before(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/data.api.tests.js
+++ b/test/api/data.api.tests.js
@@ -30,11 +30,16 @@ describe(`Data Export API`, function () {
 
   before(async () => {
     await openwhyd.setup();
-    await openwhyd.reset(); // to prevent side effects between test suites
   });
 
   after(async () => {
     await openwhyd.release();
+  });
+
+  beforeEach(async () => {
+    this.timeout(4000);
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
+    return addTrackToPlaylist(user, plName, track);
   });
 
   // add a playlist with one track
@@ -45,10 +50,6 @@ describe(`Data Export API`, function () {
     eId: '/yt/59MdiE1IsBY',
     url: '//youtube.com/watch?v=59MdiE1IsBY',
   };
-  before(function () {
-    this.timeout(4000);
-    return addTrackToPlaylist(user, plName, track);
-  });
 
   describe(`provides profile tracks`, () => {
     it(`of given user id, as JSON, using callback`, async () => {

--- a/test/api/follow.api.tests.js
+++ b/test/api/follow.api.tests.js
@@ -34,11 +34,14 @@ describe(`follow api`, function () {
 
   before(async () => {
     await openwhyd.setup();
-    await openwhyd.reset(); // to prevent side effects between test suites
   });
 
   after(async () => {
     await openwhyd.release();
+  });
+
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
   });
 
   it(`allows a user to follow another user`, async function () {

--- a/test/api/follow.api.tests.js
+++ b/test/api/follow.api.tests.js
@@ -3,7 +3,7 @@
 const querystring = require('querystring');
 const assert = require('assert');
 
-const { DUMMY_USER, ADMIN_USER, cleanup } = require('../fixtures.js');
+const { DUMMY_USER, ADMIN_USER } = require('../fixtures.js');
 const api = require('../api-client.js');
 const {
   OpenwhydTestEnv,
@@ -32,7 +32,7 @@ describe(`follow api`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true })); // to prevent side effects between tests
+  before(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/follow.api.tests.js
+++ b/test/api/follow.api.tests.js
@@ -32,10 +32,9 @@ describe(`follow api`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset()); // to prevent side effects between tests
-
   before(async () => {
     await openwhyd.setup();
+    await openwhyd.reset(); // to prevent side effects between test suites
   });
 
   after(async () => {

--- a/test/api/legacy.post.api.tests.js
+++ b/test/api/legacy.post.api.tests.js
@@ -164,7 +164,7 @@ describe(`post api - independent tests`, function () {
   });
 
   beforeEach(async () => {
-    await openwhyd.reset(); // to prevent side effects between tests
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
   });
 
   it('should delete a post', async function () {

--- a/test/api/legacy.post.api.tests.js
+++ b/test/api/legacy.post.api.tests.js
@@ -6,18 +6,21 @@ const util = require('util');
 const { START_WITH_ENV_FILE } = process.env;
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
 
-const backend = new OpenwhydTestEnv({
+const openwhyd = new OpenwhydTestEnv({
   startWithEnv: START_WITH_ENV_FILE,
 });
 
 describe(`post api - legacy`, function () {
   before(async () => {
-    await backend.setup();
-    await backend.reset(); // to prevent side effects between test suites (there are side effects between tests in this file...)
+    await openwhyd.setup();
   });
 
   after(async () => {
-    await backend.release();
+    await openwhyd.release();
+  });
+
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
   });
 
   let pId, uId;
@@ -161,15 +164,15 @@ describe(`post api - legacy`, function () {
 
 describe(`post api - independent tests`, function () {
   before(async () => {
-    await backend.setup();
+    await openwhyd.setup();
   });
 
   after(async () => {
-    await backend.release();
+    await openwhyd.release();
   });
 
   // to prevent side effects between tests
-  beforeEach(async () => await backend.reset());
+  beforeEach(async () => await openwhyd.reset());
 
   it('should delete a post', async function () {
     const { jar } = await util.promisify(api.loginAs)(DUMMY_USER);

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const util = require('util');
 const request = require('request');
 
-const { DUMMY_USER, URL_PREFIX } = require('../fixtures.js');
+const { DUMMY_USER } = require('../fixtures.js');
 const api = require('../api-client.js');
 const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
@@ -35,7 +35,7 @@ describe(`playlist api`, function () {
             action: 'create',
             name: playlistName,
           },
-          url: `${URL_PREFIX}/api/playlist`,
+          url: `${openwhyd.getURL()}/api/playlist`,
         },
         (error, response, body) =>
           error ? reject(error) : resolve({ response, body }),
@@ -69,7 +69,7 @@ describe(`playlist api`, function () {
               id: 0,
               name: newName,
             },
-            url: `${URL_PREFIX}/api/playlist`,
+            url: `${openwhyd.getURL()}/api/playlist`,
           },
           (error, response, body) =>
             error ? reject(error) : resolve({ response, body }),

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -20,7 +20,7 @@ describe(`playlist api`, function () {
   });
 
   beforeEach(async () => {
-    await openwhyd.reset(); // to prevent side effects between test suites
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
   });
 
   it('should create a playlist', async function () {

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -4,12 +4,13 @@ const request = require('request');
 
 const { DUMMY_USER, URL_PREFIX } = require('../fixtures.js');
 const api = require('../api-client.js');
-const { START_WITH_ENV_FILE } = process.env;
 const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
 describe(`playlist api`, function () {
-  const openwhyd = new OpenwhydTestEnv({ startWithEnv: START_WITH_ENV_FILE });
+  const openwhyd = new OpenwhydTestEnv({
+    startWithEnv: process.env.START_WITH_ENV_FILE,
+  });
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/playlist.api.tests.js
+++ b/test/api/playlist.api.tests.js
@@ -5,11 +5,7 @@ const request = require('request');
 const { DUMMY_USER, URL_PREFIX } = require('../fixtures.js');
 const api = require('../api-client.js');
 const { START_WITH_ENV_FILE } = process.env;
-const {
-  OpenwhydTestEnv,
-  ObjectId,
-  connectToMongoDB,
-} = require('../approval-tests-helpers.js');
+const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
 describe(`playlist api`, function () {

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -21,8 +21,6 @@ describe(`post api`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset()); // to prevent side effects between test suites
-
   before(async () => {
     await openwhyd.setup();
   });
@@ -30,6 +28,8 @@ describe(`post api`, function () {
   after(async () => {
     await openwhyd.release();
   });
+
+  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   beforeEach(async () => {
     post = {

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -12,14 +12,18 @@ const {
 const api = require('../api-client.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
+const openwhyd = new OpenwhydTestEnv({
+  startWithEnv: process.env.START_WITH_ENV_FILE,
+});
+
 describe(`post api`, function () {
   const loggedUser = DUMMY_USER;
   const otherUser = ADMIN_USER;
-  let post;
-  let jar;
-  const openwhyd = new OpenwhydTestEnv({
-    startWithEnv: process.env.START_WITH_ENV_FILE,
+  const post = Object.freeze({
+    eId: `/yt/${randomString()}`,
+    name: `Lullaby - Jack Johnson and Matt Costa`,
   });
+  let jar;
 
   before(async () => {
     await openwhyd.setup();
@@ -29,14 +33,8 @@ describe(`post api`, function () {
     await openwhyd.release();
   });
 
-  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
-
   beforeEach(async () => {
-    post = {
-      eId: `/yt/${randomString()}`,
-      name: `Lullaby - Jack Johnson and Matt Costa`,
-    };
-
+    await openwhyd.reset(); // to prevent side effects between tests
     ({ jar } = await util.promisify(api.loginAs)(loggedUser));
   });
 

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -193,7 +193,7 @@ describe(`post api`, function () {
     assert.equal(postedTrack.uId, DUMMY_USER.id);
     assert.equal(postedTrack.uNm, DUMMY_USER.name);
     assert.ok(postedTrack._id);
-    assert.ok(postedTrack.pl.id);
+    assert.equal(postedTrack.pl.id, 0);
     assert.equal(postedTrack.pl.name, newPlayListName);
   });
 

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -34,7 +34,7 @@ describe(`post api`, function () {
   });
 
   beforeEach(async () => {
-    await openwhyd.reset(); // to prevent side effects between tests
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
     ({ jar } = await util.promisify(api.loginAs)(loggedUser));
   });
 

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -5,7 +5,6 @@ const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 
 const {
   ADMIN_USER,
-  cleanup,
   URL_PREFIX,
   DUMMY_USER,
   FAKE_ID,
@@ -22,7 +21,7 @@ describe(`post api`, function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true })); // to prevent side effects between test suites
+  before(async () => await openwhyd.reset()); // to prevent side effects between test suites
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -12,10 +12,6 @@ const {
 const api = require('../api-client.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
-const openwhyd = new OpenwhydTestEnv({
-  startWithEnv: process.env.START_WITH_ENV_FILE,
-});
-
 describe(`post api`, function () {
   const loggedUser = DUMMY_USER;
   const otherUser = ADMIN_USER;
@@ -24,6 +20,10 @@ describe(`post api`, function () {
     name: `Lullaby - Jack Johnson and Matt Costa`,
   });
   let jar;
+
+  const openwhyd = new OpenwhydTestEnv({
+    startWithEnv: process.env.START_WITH_ENV_FILE,
+  });
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -3,12 +3,7 @@ const util = require('util');
 const request = require('request');
 const { OpenwhydTestEnv, ObjectId } = require('../approval-tests-helpers.js');
 
-const {
-  ADMIN_USER,
-  URL_PREFIX,
-  DUMMY_USER,
-  FAKE_ID,
-} = require('../fixtures.js');
+const { ADMIN_USER, DUMMY_USER, FAKE_ID } = require('../fixtures.js');
 const api = require('../api-client.js');
 const randomString = () => Math.random().toString(36).substring(2, 9);
 
@@ -20,6 +15,7 @@ describe(`post api`, function () {
     name: `Lullaby - Jack Johnson and Matt Costa`,
   });
   let jar;
+  let URL_PREFIX;
 
   const openwhyd = new OpenwhydTestEnv({
     startWithEnv: process.env.START_WITH_ENV_FILE,
@@ -27,6 +23,7 @@ describe(`post api`, function () {
 
   before(async () => {
     await openwhyd.setup();
+    URL_PREFIX = openwhyd.getURL();
   });
 
   after(async () => {

--- a/test/api/security.api.tests.js
+++ b/test/api/security.api.tests.js
@@ -2,7 +2,7 @@ const { promisify } = require('util');
 const assert = require('assert');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { ADMIN_USER, cleanup, URL_PREFIX } = require('../fixtures.js');
+const { ADMIN_USER, URL_PREFIX } = require('../fixtures.js');
 const apiClient = require('../api-client.js');
 
 const postRaw = promisify(apiClient.postRaw);
@@ -13,7 +13,7 @@ describe('security', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true }));
+  before(async () => await openwhyd.reset());
 
   before(async () => {
     await openwhyd.setup();

--- a/test/api/security.api.tests.js
+++ b/test/api/security.api.tests.js
@@ -2,7 +2,7 @@ const { promisify } = require('util');
 const assert = require('assert');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { ADMIN_USER, URL_PREFIX } = require('../fixtures.js');
+const { ADMIN_USER } = require('../fixtures.js');
 const apiClient = require('../api-client.js');
 
 const postRaw = promisify(apiClient.postRaw);
@@ -12,9 +12,11 @@ describe('security', function () {
   const openwhyd = new OpenwhydTestEnv({
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
+  let URL_PREFIX;
 
   before(async () => {
     await openwhyd.setup();
+    URL_PREFIX = openwhyd.getURL();
   });
 
   after(async () => {

--- a/test/api/security.api.tests.js
+++ b/test/api/security.api.tests.js
@@ -21,7 +21,9 @@ describe('security', function () {
     await openwhyd.release();
   });
 
-  beforeEach(async () => await openwhyd.reset());
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
+  });
 
   describe('Open Redirect from /login', () => {
     it('should allow redirect to /stream', async () => {

--- a/test/api/security.api.tests.js
+++ b/test/api/security.api.tests.js
@@ -13,8 +13,6 @@ describe('security', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset());
-
   before(async () => {
     await openwhyd.setup();
   });
@@ -22,6 +20,8 @@ describe('security', function () {
   after(async () => {
     await openwhyd.release();
   });
+
+  beforeEach(async () => await openwhyd.reset());
 
   describe('Open Redirect from /login', () => {
     it('should allow redirect to /stream', async () => {

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -11,8 +11,6 @@ describe('user api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(async () => await openwhyd.reset()); // to prevent side effects between tests
-
   before(async () => {
     await openwhyd.setup();
   });
@@ -20,6 +18,8 @@ describe('user api', function () {
   after(async () => {
     await openwhyd.release();
   });
+
+  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   it("should return a 404 for user handle that doesn't exist", async () => {
     const { response } = await util.promisify(api.getRaw)(null, '/nobody');

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const util = require('util');
 
 const { OpenwhydTestEnv } = require('../approval-tests-helpers.js');
-const { DUMMY_USER, cleanup, FAKE_ID } = require('../fixtures.js');
+const { DUMMY_USER, FAKE_ID } = require('../fixtures.js');
 const api = require('../api-client.js');
 
 describe('user api', function () {
@@ -11,7 +11,7 @@ describe('user api', function () {
     startWithEnv: process.env.START_WITH_ENV_FILE,
   });
 
-  before(cleanup.bind(this, { silent: true })); // to prevent side effects between tests
+  before(async () => await openwhyd.reset()); // to prevent side effects between tests
 
   before(async () => {
     await openwhyd.setup();
@@ -104,7 +104,7 @@ describe('user api', function () {
   });
 
   describe(`setting user data`, function () {
-    before(cleanup.bind(this, { silent: true })); // to prevent side effects between tests
+    before(async () => await openwhyd.reset()); // to prevent side effects between tests
 
     it(`updates the user's name`, function (done) {
       api.loginAs(DUMMY_USER, function (error, { body, jar }) {

--- a/test/api/user.api.tests.js
+++ b/test/api/user.api.tests.js
@@ -19,7 +19,9 @@ describe('user api', function () {
     await openwhyd.release();
   });
 
-  beforeEach(async () => await openwhyd.reset()); // to prevent side effects between tests
+  beforeEach(async () => {
+    await openwhyd.reset(); // prevent side effects between tests by resetting db state
+  });
 
   it("should return a 404 for user handle that doesn't exist", async () => {
     const { response } = await util.promisify(api.getRaw)(null, '/nobody');

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -239,7 +239,8 @@ class OpenwhydTestEnv {
   /** Clears and (re)initializes Openwhyd's database, for testing. */
   async reset() {
     if (!this.isSetup) throw new Error('please call setup() before reset()');
-    await resetTestDb({ silent: true, env: this.getEnv() });
+    await resetTestDb({ silent: false, env: this.getEnv() });
+    await this.refreshCache();
   }
 
   /* Refresh openwhyd's in-memory cache of users, e.g. to allow freshly added users to login. */

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -195,10 +195,15 @@ async function startOpenwhydServer({ startWithEnv, port }) {
   }
 }
 
+/**
+ * Manages the environment and execution of Openwhyd server and its database, for automated tests.
+ * The goal is to make automated tests easier to write, by abstracting technical details about the backend under test.
+ */
 class OpenwhydTestEnv {
   /**
-   * If port is not provided, OpenwhydTestEnv will start Openwhyd's server programmatically,
-   * reading environment variables from the file provided in startWithEnv.
+   * If `startWithEnv` is provided, `setup()` will start Openwhyd's server programmatically,
+   * by reading environment variables from the corresponding file.
+   * Otherwise, please provide the `port` on which Openwhyd is currently running.
    * @param {{ startWithEnv: string } | { port: number | string }} options
    */
   constructor(options) {
@@ -206,7 +211,13 @@ class OpenwhydTestEnv {
     this.isSetup = false;
   }
 
-  /** Start Openwhyd, if startWithEnv was provided at time of instanciation. */
+  /**
+   * Start Openwhyd, if `startWithEnv` was provided at time of instanciation.
+   * Don't forget:
+   * - call `reset()` to clear and (re)initialize Openwhyd's database, before each test;
+   * - call `refreshCache()` after every modification to the `user` collection;
+   * - call `release()` to stop Openwhyd, when you're done testing.
+   */
   async setup() {
     if ('startWithEnv' in this.options)
       this.serverProcess = await startOpenwhydServer(this.options);

--- a/test/approval-tests-helpers.js
+++ b/test/approval-tests-helpers.js
@@ -239,7 +239,7 @@ class OpenwhydTestEnv {
   /** Clears and (re)initializes Openwhyd's database, for testing. */
   async reset() {
     if (!this.isSetup) throw new Error('please call setup() before reset()');
-    await resetTestDb({ silent: false, env: this.getEnv() });
+    await resetTestDb({ silent: true, env: this.getEnv() });
     await this.refreshCache();
   }
 

--- a/test/approval/hot-tracks/hot-tracks.approval.test.js
+++ b/test/approval/hot-tracks/hot-tracks.approval.test.js
@@ -94,7 +94,7 @@ describe('Hot Tracks (approval tests - to be replaced later by unit tests)', () 
   });
 
   beforeEach(async () => {
-    await backend.reset();
+    await backend.reset(); // prevent side effects between tests by resetting db state
     await db.collection('user').deleteMany({}); // clear users
     await db.collection('post').deleteMany({}); // clear posts
     await db.collection('track').deleteMany({}); // clear tracks

--- a/test/approval/posting/posting.approval.tests.js
+++ b/test/approval/posting/posting.approval.tests.js
@@ -46,7 +46,7 @@ const makePostFromBk = (user) => ({
   },
 });
 
-const backend = new OpenwhydTestEnv({
+const openwhyd = new OpenwhydTestEnv({
   startWithEnv: START_WITH_ENV_FILE,
   port: PORT,
 });
@@ -70,13 +70,13 @@ async function setupTestEnv() {
   };
   await insertTestData(MONGODB_URL, context.testDataCollections);
   // start openwhyd server
-  await backend.setup(); // starts openwhyd, or refreshes its state if already running
+  await openwhyd.setup(); // starts openwhyd, or refreshes its state if already running
   return context;
 }
 
 async function teardownTestEnv() {
   if (!DONT_KILL) {
-    await backend.release();
+    await openwhyd.release();
   }
 }
 
@@ -172,7 +172,7 @@ describe('When posting a track using the bookmarklet, using a HTTP GET request',
         request.get(
           {
             jar,
-            url: `${backend.getURL()}/api/post?action=insert&eId=${encodeURIComponent(
+            url: `${openwhyd.getURL()}/api/post?action=insert&eId=${encodeURIComponent(
               post.eId,
             )}&name=${encodeURIComponent(
               post.name,
@@ -228,7 +228,7 @@ describe('When renaming a track', function () {
             _id: postedTrack._id.toString(),
             pl: { id: null, name: 'full stream' },
           },
-          url: `${backend.getURL()}/api/post`,
+          url: `${openwhyd.getURL()}/api/post`,
         },
         (error, response, body) =>
           error ? reject(error) : resolve({ response, body }),

--- a/test/approval/routes/routes.approval.tests.js
+++ b/test/approval/routes/routes.approval.tests.js
@@ -20,7 +20,7 @@ const MONGODB_URL =
 
 const testDataDir = `${__dirname}/test-data`;
 
-const backend = new OpenwhydTestEnv({
+const openwhyd = new OpenwhydTestEnv({
   startWithEnv: START_WITH_ENV_FILE,
   port: PORT,
 });
@@ -33,14 +33,14 @@ test.before(async (t) => {
   };
   await insertTestData(MONGODB_URL, testDataCollections);
 
-  await backend.setup(); // starts openwhyd, or refreshes its state if already running
+  await openwhyd.setup(); // starts openwhyd, or refreshes its state if already running
   t.context.openwhyd = require('../../api-client');
   t.context.getUser = (id) =>
     testDataCollections.user.find(({ _id }) => id === _id.toString());
 });
 
 test.after(async (t) => {
-  if (!DONT_KILL) await backend.release();
+  if (!DONT_KILL) await openwhyd.release();
 });
 
 const personas = [

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -50,15 +50,21 @@ exports.TEST_USER = Object.freeze({
   md5: '42b27efc1480b4fe6d7eaa5eec47424d', // MD5 hash of password
 });
 
-/** Clears and (re)initializes Openwhyd's database, for testing. */
+/**
+ * Clears and (re)initializes Openwhyd's database, for automated tests.
+ * Call this before each test to prevent side effects between tests.
+ * Requires MONGODB_HOST and MONGODB_PORT env vars.
+ * @param {object} opts
+ * @param {typeof process.env} opts.env - environment variables to pass to Openwhyd server
+ * @param {boolean} opts.silent - if true, no logs from Openwhyd server will be displayed
+ */
 exports.resetTestDb = async (
   { env, silent } = { env: process.env, silent: false },
 ) => {
   if (!env?.MONGODB_HOST) throw new Error('missing env var: MONGODB_HOST');
   if (!env?.MONGODB_PORT) throw new Error('missing env var: MONGODB_PORT');
   const resetDbProcess = childProcess.fork('test/reset-test-db.js', {
-    // @ts-ignore
-    env: { ...env, ...(!silent ? { DEBUG: true } : {}) },
+    env: { ...env, ...(!silent ? { DEBUG: 'true' } : {}) },
     silent: true,
   });
   if (!silent)
@@ -71,9 +77,12 @@ exports.resetTestDb = async (
 };
 
 /**
- * Call this before each test to prevent side effects between tests.
+ * Clears and (re)initializes Openwhyd's database, for automated tests.
+ * Environment variables will be read from file, if provided in START_WITH_ENV_FILE.
  * Don't forget to bind to `this`, so Mocha's timeout can be adjusted.
  * Note: For tests that need Openwhyd server to run, use OpenwhydTestEnv.reset() instead.
+ * @param {object} opts
+ * @param {boolean} opts.silent - if true, no logs from Openwhyd server will be displayed
  */
 exports.cleanup = async function ({ silent } = { silent: false }) {
   this.timeout(4000);

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -68,7 +68,7 @@ exports.resetTestDb = async (
 /**
  * Call this before each test to prevent side effects between tests.
  * Don't forget to bind to `this`, so Mocha's timeout can be adjusted.
- * @deprecated Use OpenwhydTestEnv.reset() instead.
+ * Note: For tests that need Openwhyd server to run, use OpenwhydTestEnv.reset() instead.
  */
 exports.cleanup = async function ({ silent } = { silent: false }) {
   this.timeout(4000);

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -57,9 +57,14 @@ exports.resetTestDb = async (
   if (!env?.MONGODB_HOST) throw new Error('missing env var: MONGODB_HOST');
   if (!env?.MONGODB_PORT) throw new Error('missing env var: MONGODB_PORT');
   const resetDbProcess = childProcess.fork('test/reset-test-db.js', {
-    env,
-    silent,
+    // @ts-ignore
+    env: { ...env, ...(!silent ? { DEBUG: true } : {}) },
+    silent: true,
   });
+  if (!silent)
+    resetDbProcess.stdout.on('data', (txt) =>
+      console.debug(`[cleanup] ${txt}`),
+    );
   resetDbProcess.stderr.on('data', (txt) => console.error(`[cleanup] ${txt}`));
   resetDbProcess.on('error', (err) => console.trace('[cleanup] error:', err));
   return new Promise((resolve) => resetDbProcess.on('close', () => resolve()));

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -17,8 +17,6 @@ exports.loadEnvVars = async (file) => {
 
 exports.FAKE_ID = 'a0000000000000000000000a';
 
-exports.URL_PREFIX = 'http://localhost:8080';
-
 // inserted by config/initdb_testing.js
 exports.ADMIN_USER = Object.freeze({
   id: '000000000000000000000001',

--- a/test/integration/notif-tests.js
+++ b/test/integration/notif-tests.js
@@ -5,7 +5,7 @@ const notifModel = require('../../app/models/notif.js');
 
 const { ObjectId } = require('mongodb');
 const { initMongoDb } = require('../mongodb-client.js'); // uses MONGODB_HOST, MONGODB_PORT, MONGODB_USER, MONGODB_PASS, MONGODB_DATABASE env vars
-const { ADMIN_USER, cleanup } = require('../fixtures.js');
+const { ADMIN_USER, resetTestDb } = require('../fixtures.js');
 
 let mongodb, db;
 
@@ -115,7 +115,7 @@ describe('notifications', function () {
   this.timeout(5000);
 
   // reset database state and seed fixtures (including ADMIN_USER)
-  before(cleanup.bind(this, { silent: true }));
+  before(async () => await resetTestDb({ env: process.env, silent: false }));
 
   before(initDb);
 

--- a/test/integration/notif-tests.js
+++ b/test/integration/notif-tests.js
@@ -115,7 +115,7 @@ describe('notifications', function () {
   this.timeout(5000);
 
   // reset database state and seed fixtures (including ADMIN_USER)
-  before(async () => await resetTestDb({ env: process.env, silent: false }));
+  before(async () => await resetTestDb({ env: process.env, silent: true }));
 
   before(initDb);
 

--- a/test/integration/user.repository.tests.js
+++ b/test/integration/user.repository.tests.js
@@ -28,9 +28,7 @@ describe('MongoDB User Repository', function () {
     mongodb = await initMongoDb({ silent: true });
   });
 
-  beforeEach(
-    async () => await resetTestDb({ env: process.env, silent: false }),
-  );
+  beforeEach(async () => await resetTestDb({ env: process.env, silent: true }));
 
   it('should throw exception when user is invalid', async () => {
     try {

--- a/test/integration/user.repository.tests.js
+++ b/test/integration/user.repository.tests.js
@@ -2,7 +2,7 @@
 
 const assert = require('assert');
 const { initMongoDb } = require('../mongodb-client'); // uses MONGODB_HOST, MONGODB_PORT, MONGODB_USER, MONGODB_PASS, MONGODB_DATABASE env vars
-const { cleanup } = require('../fixtures.js');
+const { resetTestDb } = require('../fixtures.js');
 const {
   readMongoDocuments,
   insertTestData,
@@ -28,7 +28,9 @@ describe('MongoDB User Repository', function () {
     mongodb = await initMongoDb({ silent: true });
   });
 
-  beforeEach(cleanup.bind(this, { silent: true }));
+  beforeEach(
+    async () => await resetTestDb({ env: process.env, silent: false }),
+  );
 
   it('should throw exception when user is invalid', async () => {
     try {


### PR DESCRIPTION
Fixes #684.

Follow up of PR #687.

Improvements:
- Make sure that db state is reset everywhere it needs to be, ideally before each test, to ensure state isolation and prevent side effects.
- Use `OpenwhydTestEnv.reset()` instead of `fixtures.cleanup()`, where applicable.
