### PR TITLE
fix(ci): update `CHANGELOG.md` on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,8 +317,6 @@ jobs:
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
-      - run: npm ci --prefer-offline --no-audit
-        if: github.event_name == 'push'
       - run: make release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,17 +319,7 @@ jobs:
           cache: 'npm'
       - run: npm ci --prefer-offline --no-audit
         if: github.event_name == 'push'
-      - name: npx --yes semantic-release
-        run: |
-          # we install just semantic-release and its plugins, without considering package.json
-          mkdir "tmp-release"
-          npm --prefix "tmp-release" install --no-save \
-            "semantic-release@17.3.1" \
-            "@semantic-release/release-notes-generator@11.0.7" \
-            "@semantic-release/changelog@5.0.1" \
-            "@semantic-release/git@9.0.0" \
-            && tmp-release/node_modules/.bin/semantic-release
-          rm -rf "tmp-release"
+      - run: make release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
       - name: Create Docker tags

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,7 @@ jobs:
           mkdir "tmp-release"
           npm --prefix "tmp-release" install --no-save \
             "semantic-release@17.3.1" \
+            "@semantic-release/release-notes-generator@11.0.7" \
             "@semantic-release/changelog@5.0.1" \
             "@semantic-release/git@9.0.0" \
             && tmp-release/node_modules/.bin/semantic-release

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -29,6 +29,7 @@ module.exports = {
         },
       },
     ],
+    '@semantic-release/release-notes-generator',
     '@semantic-release/changelog',
     '@semantic-release/git',
     '@semantic-release/npm',

--- a/Makefile
+++ b/Makefile
@@ -91,14 +91,14 @@ ci: ## Run automated tests defined in GitHub Actions CI workflow.
 	# TODO: run other CI jobs too.
 	@rm -f github_event.tmp
 
-release: ## Release a new version of Openwhyd.
+release: ## Release a new version of Openwhyd. (To run on CI)
 	# we install just semantic-release and its plugins, without considering package.json
-	mkdir "tmp-release"
+	mkdir -p "tmp-release"
 	npm --prefix "tmp-release" install --no-save \
-		"semantic-release@17.3.1" \
+		"semantic-release@21.1.1" \
 		"@semantic-release/release-notes-generator@11.0.7" \
-		"@semantic-release/changelog@5.0.1" \
-		"@semantic-release/git@9.0.0" \
+		"@semantic-release/changelog@6.0.3" \
+		"@semantic-release/git@10.0.1" \
 		&& tmp-release/node_modules/.bin/semantic-release
 	rm -rf "tmp-release"
 

--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,20 @@ ci: ## Run automated tests defined in GitHub Actions CI workflow.
 	# TODO: run other CI jobs too.
 	@rm -f github_event.tmp
 
+release: ## Release a new version of Openwhyd.
+	# we install just semantic-release and its plugins, without considering package.json
+	mkdir "tmp-release"
+	npm --prefix "tmp-release" install --no-save \
+		"semantic-release@17.3.1" \
+		"@semantic-release/release-notes-generator@11.0.7" \
+		"@semantic-release/changelog@5.0.1" \
+		"@semantic-release/git@9.0.0" \
+		&& tmp-release/node_modules/.bin/semantic-release
+	rm -rf "tmp-release"
+
 help: ## This help.
 	@echo 'Available targets:'
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 # PHONY deps are task dependencies that are not represented by files
-.PHONY: install build dev start restart restart-to-latest lint docker-seed test test-unit test-integration test-e2e test-approval test-in-docker ci help
+.PHONY: install build dev start restart restart-to-latest lint docker-seed test test-unit test-integration test-e2e test-approval test-in-docker ci release help


### PR DESCRIPTION
## What does this PR do / solve?

Problem: `CHANGELOG.md` has not been updated by semantic-release for 2 years!

<img width="1106" alt="image" src="https://github.com/openwhyd/openwhyd/assets/531781/b9a0eca0-d967-4019-a529-a10166b44910">

## Overview of changes

Add `@semantic-release/release-notes-generator` plugin, as suggested in https://www.npmjs.com/package/@semantic-release/changelog.
