### PR TITLE
fix(error-handling): don't callback twice upon rejection

### DIFF
--- a/app/controllers/admin/db.js
+++ b/app/controllers/admin/db.js
@@ -96,8 +96,10 @@ var fileGenerators = {
       col
         .find(p, { limit: limit })
         .toArray()
-        .catch((error) => cb({ error: error }))
-        .then((items) => cb(items));
+        .then(
+          (items) => cb(items),
+          (error) => cb({ error: error }),
+        );
     }
   },
   'find.txt': wrapJsonGeneratorToText('find.json'),

--- a/app/controllers/admin/invites.js
+++ b/app/controllers/admin/invites.js
@@ -15,8 +15,10 @@ const fetchUsers = function (table, handler, options) {
   mongodb.collections[table]
     .find({}, options)
     .toArray()
-    .catch(handler)
-    .then((res) => handler(null, res));
+    .then(
+      (res) => handler(null, res),
+      (err) => handler(err),
+    );
 };
 
 const inviteUser = function (email, handler) {

--- a/app/models/activity.js
+++ b/app/models/activity.js
@@ -28,11 +28,13 @@ exports.fetch = function (q, options, callback) {
   getCol()
     .find(q, options)
     .toArray()
-    .catch((err) => {
-      console.trace('error in activity.fetch:', err);
-      callback();
-    })
-    .then((res) => callback(res));
+    .then(
+      (res) => callback(res),
+      (err) => {
+        console.trace('error in activity.fetch:', err);
+        callback();
+      },
+    );
 };
 
 exports.add = async function (d, callback) {

--- a/app/models/track.js
+++ b/app/models/track.js
@@ -93,11 +93,16 @@ exports.fetch = function (params, handler) {
   mongodb.collections['track']
     .find({}, params)
     .toArray()
-    .catch(() => handler())
-    .then(function (results) {
-      // console.log('=> fetched ' + results.length + ' tracks');
-      if (handler) handler(results);
-    });
+    .then(
+      function (results) {
+        // console.log('=> fetched ' + results.length + ' tracks');
+        if (handler) handler(results);
+      },
+      (err) => {
+        console.trace('trackModel.fetch', err);
+        handler();
+      },
+    );
 };
 
 exports.fetchTrackByEid = function (eId, cb) {
@@ -161,8 +166,13 @@ function fetchPostsByEid(eId, cb) {
   mongodb.collections['post']
     .find(criteria, POST_FETCH_OPTIONS)
     .toArray()
-    .catch(() => cb())
-    .then((posts) => cb(posts));
+    .then(
+      (posts) => cb(posts),
+      (err) => {
+        console.trace('fetchPostsByEid', err);
+        cb();
+      },
+    );
 }
 
 // called when a track is updated/deleted by a user


### PR DESCRIPTION
Similar to #703.

## What does this PR do / solve?

Incorrect error handling logic:

```js
search()
  .catch(/* ... */) // error/`reject` handling code
  .then(/* ... */) // success/`resolve` handling code
```

... causing both error and success handling code to run.

## Overview of changes

Fix promise handling so that callbacks are called only once: if promise resolves OR rejects, not both.

Will also possibly fix several `Can't set headers after they are sent` errors witnessed in production logs.
