### PR TITLE
fix(hot-tracks): don't include invalid SoundCloud `eId`

### DIFF
--- a/app/models/track.js
+++ b/app/models/track.js
@@ -91,7 +91,7 @@ exports.fetch = function (params, handler) {
   params = params || {};
   params.sort = params.sort || [['score', 'desc']];
   mongodb.collections['track']
-    .find({}, params)
+    .find({ eId: { $ne: '/sc/undefined' } }, params) // exclude invalid eId values, cf https://github.com/openwhyd/openwhyd/issues/718#issuecomment-1710359006
     .toArray()
     .then(
       function (results) {

--- a/test/unit/hot-tracks.tests.js
+++ b/test/unit/hot-tracks.tests.js
@@ -1,3 +1,5 @@
+// $ npx mocha test/unit/hot-tracks.tests.js
+
 const assert = require('assert');
 const { getHotTracks } = require('../../app/features/hot-tracks.js');
 


### PR DESCRIPTION
Contributes to #718 and #614.

## What does this PR do / solve?

The top track listed on the [hot tracks page](https://openwhyd.org/hot) has an invalid SoundCloud `eId`, causing its score to artificially accumulate the stats of all posts with that same invalid `eId: "/sc/undefined"`.

```json
    {
      "_id": "53f5d7af7b4e770b172679bc",
      "uId": "52e2620f7e91c862b2b3f66a",
      "uNm": "Rien",
      "text": "",
      "pl": { "name": "Balkan Beat Gypsy #03", "id": 144 },
      "name": "Haris Pilton - Gypsy Partizans (2013)",
      "eId": "/sc/undefined",
      "img": "https://i1.sndcdn.com/artworks-000047093292-y6wbnv-large.jpg?e76cf77",
      "nbP": 958,
      "lov": [
        "53da584ce04b7b4fca7cf528",
        "518b5a447e91c862b2adea1a",
        "6485e598d1b1033fa650d66b"
      ],
      "nbR": 213,
      "score": 900,
      "nbL": 19,
      "prev": 900,
      "trackId": "54bf88e3e04b7b4fca82c18f",
      "rankIncr": 0,
      "trackUrl": "//soundcloud.com/undefined",
      "isLoved": false
    }
```

## Overview of changes

Until we fix the root cause (see #614), skip tracks with invalid soundcloud `eId`.
