### PR TITLE
fix(logs): reduce error logs from fieldSetters

### DIFF
--- a/app/controllers/api/user.js
+++ b/app/controllers/api/user.js
@@ -143,11 +143,9 @@ const fieldSetters = {
         console.log('deleting previous profile pic: ' + user.img);
         await uploadCtr
           .deleteFile(user.img)
-          .catch((err) =>
+          .catch(() =>
             console.log(
               'failed to delete existing profile image in fieldSetters.img',
-              err,
-              err.stack,
             ),
           );
       }


### PR DESCRIPTION
## What does this PR do / solve?

I want to receive fewer warnings like this one from Datadog:

<img width="618" alt="image" src="https://github.com/openwhyd/openwhyd/assets/531781/39e7afe2-317f-4027-b63e-94e6c3497849">

