### PR TITLE
fix: end worker process in case of error

### DIFF
--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -145,7 +145,7 @@ exports.forEach2 = async function (colName, params, handler) {
         // TODO: close the cursor whenever we've run out of documents?
       },
       (err) => {
-        console.error('[db] mongodb.forEach2 ERROR', err);
+        console.trace('[db] mongodb.forEach2 ERROR', err);
         handler({ error: err }, undefined, (cb) => cursor.close().then(cb, cb));
         cursor.close(); // TODO: prevent closing twice?
       },

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -249,7 +249,8 @@ exports.fetchMulti = async function (q, options, handler) {
     .project(fields ?? {})
     .toArray();
   processUsers(array);
-  handler(array);
+  handler?.(array);
+  return array;
 };
 
 /**
@@ -598,14 +599,14 @@ exports.getEmailNotifsFreq = function (user) {
   return freq;
 };
 
-exports.fetchEmailNotifsToSend = function (now = new Date(), cb) {
+exports.fetchEmailNotifsToSend = async function (now = new Date()) {
   const criteria = {
     'pref.pendEN': { $gt: 0 }, // number of pending email notifs
   };
   if (!TESTING_DIGEST)
     criteria['pref.nextEN'] = { $lte: msToDigestTimestamp(now) }; // next email notif date
 
-  exports.fetchMulti(criteria, {}, cb);
+  return await exports.fetchMulti(criteria, {});
 };
 
 exports.incrementNotificationCounter = function (uId, handler) {


### PR DESCRIPTION
## What does this PR do / solve?

Whenever a db error happens during the generation of a notification digest email, the `notifEmails` worker hangs, causing a loop of `[OneAtATime] fct is trying to start before last call has ended` errors.

<img width="1185" alt="image" src="https://github.com/openwhyd/openwhyd/assets/531781/5ad3533b-2e38-4d90-8ba0-566f47049cb7">

The problem was probably revealed while migrating on #634, because of not calling "`cb`" callback functions in case of errors returned by `async` mongodb calls.

## Overview of changes

- Intercept errors, so the execution of the worker can end and be restarted later in case of unexpected interruption.
- => turn callback-based functions into `async` functions, so that errors can be intercepted.
