### PR TITLE
fix(ci): `docker-compose: command not found`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,20 +341,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Build and start services
-        run: docker-compose up --build --detach
+        run: docker compose up --build --detach
         # env:
         #   ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_TEST_APP_ID }}
         #   ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_TEST_API_KEY }}
       - name: Init database for tests
         run: make docker-seed
       - name: Run integration tests
-        run: docker-compose exec -T --env MONGODB_URL web npm run test:integration
+        run: docker compose exec -T --env MONGODB_URL web npm run test:integration
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test' # needed by mongodb integration tests (user.repository.tests.js)
       - name: Run API tests
-        run: docker-compose exec -T --env MONGODB_URL web npm run test:api:raw
+        run: docker compose exec -T --env MONGODB_URL web npm run test:api:raw
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test'
-      - name: Logs from docker-compose
+      - name: Logs from docker compose
         if: ${{ always() }} # this step is useful to troubleshoot the execution of openwhyd when tests fail
-        run: docker-compose logs
+        run: docker compose logs

--- a/Makefile
+++ b/Makefile
@@ -88,10 +88,10 @@ test-approval-update: node_modules public/js/bookmarklet.js ## Update snapshots 
 test-in-docker: ## Run tests in the Openwhyd's docker container
 	docker compose up --detach --build mongo web
 	make docker-seed
-	docker-compose exec web npm run test:functional
-	docker-compose exec web npm run test:unit
-	docker-compose exec --env MONGODB_URL='mongodb://mongo:27017/openwhyd_test' web npm run test:integration
-	docker-compose exec --env MONGODB_URL='mongodb://mongo:27017/openwhyd_test' web npm run test:api:raw
+	docker compose exec web npm run test:functional
+	docker compose exec web npm run test:unit
+	docker compose exec --env MONGODB_URL='mongodb://mongo:27017/openwhyd_test' web npm run test:integration
+	docker compose exec --env MONGODB_URL='mongodb://mongo:27017/openwhyd_test' web npm run test:api:raw
 	@echo "ℹ️ Note: Cypress will be run on the host, because it's complicated to make it work from a Docker container"
 	. ./.env-docker && npm run test:cypress
 	docker compose stop

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $ docker compose down --rmi local --remove-orphans # to stop the server and data
 
 More info about **Setup and Usage**: [INSTALL.md](docs/INSTALL.md).
 
-<!-- If you want to run it directly with `docker-compose`, checkout [Openwhyd on Docker Hub](https://hub.docker.com/r/openwhyd/openwhyd).
+<!-- If you want to run it directly with `docker compose`, checkout [Openwhyd on Docker Hub](https://hub.docker.com/r/openwhyd/openwhyd).
 
 If you want to deploy Openwhyd to a server, you can follow our guide: [How to deploy on DigitalOcean](docs/howto-deploy-on-digitalocean.md). -->
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -57,10 +57,10 @@ $ make test-in-docker
 
 ### Connect to the database
 
-If you want to connect to the MongoDB database with the `mongo` shell using `docker-compose` container:
+If you want to connect to the MongoDB database with the `mongo` shell using `docker compose` container:
 
 ```sh
-$ docker-compose exec mongo mongo mongodb://localhost:27117/openwhyd_test
+$ docker compose exec mongo mongo mongodb://localhost:27117/openwhyd_test
 ```
 
 ---

--- a/docs/howto-deploy-on-digitalocean.md
+++ b/docs/howto-deploy-on-digitalocean.md
@@ -39,7 +39,7 @@ $ ls -l
 Then run the containers.
 
 ```
-$ sudo docker-compose up -d
+$ sudo docker compose up -d
 ```
 
 This command will first pull the images from the registry and then run the containers in the background.


### PR DESCRIPTION
## What does this PR do / solve?

cf https://github.com/openwhyd/openwhyd/actions/runs/10227189085/job/28298375126#step:3:8:

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/006d7242-964b-4ab1-ac15-ae71070df0c3">

## Overview of changes

Call `docker compose` instead of legacy command: `docker-compose`.
