### PR TITLE
ci: fix error when merging coverage reports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,9 +262,10 @@ jobs:
     name: Send coverage reports to Codacy
     needs:
       # - cypress-tests
-      - approval-tests
+      # - approval-tests
       - unit-tests
       - functional-tests
+      - integration-tests
     runs-on: ubuntu-20.04
     steps:
       # - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
           cp coverage-functional-tests/.nyc_output/*.json coverage-reports
           cp coverage-integration-tests/.nyc_output/*.json coverage-reports
           npx --yes nyc merge coverage-reports .nyc_output/merged-coverage.json
-          npm run coverage:report  # stores the coverage report in coverage/lcov.info
+          npx --yes nyc report --reporter=text --reporter=lcov # stores the coverage report in coverage/lcov.info
       - uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_REPOSITORY_TOKEN_FOR_COVERAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: unit-tests-code-coverage-report
+          include-hidden-files: true
           path: |
             .nyc_output
             coverage
@@ -131,6 +132,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: functional-tests-code-coverage-report
+          include-hidden-files: true
           path: |
             .nyc_output
             coverage
@@ -160,6 +162,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: integration-tests-code-coverage-report
+          include-hidden-files: true
           path: |
             .nyc_output
             coverage
@@ -242,6 +245,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: cypress-code-coverage-report
+          include-hidden-files: true
           path: |
             .nyc_output
             coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
       - integration-tests
     runs-on: ubuntu-20.04
     steps:
-      # - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       # - uses: actions/download-artifact@v3
       #   with:
       #     name: cypress-code-coverage-report
@@ -298,7 +298,7 @@ jobs:
           cp coverage-functional-tests/.nyc_output/*.json coverage-reports
           cp coverage-integration-tests/.nyc_output/*.json coverage-reports
           npx --yes nyc merge coverage-reports .nyc_output/merged-coverage.json
-          npx --yes nyc report --reporter=text --reporter=lcov # stores the coverage report in coverage/lcov.info
+          npm run coverage:report  # stores the coverage report in coverage/lcov.info
       - uses: codacy/codacy-coverage-reporter-action@master
         with:
           project-token: ${{ secrets.CODACY_REPOSITORY_TOKEN_FOR_COVERAGE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
   coverage:
     name: Send coverage reports to Codacy
     needs:
-      # - cypress-tests
+      - cypress-tests
       # - approval-tests
       - unit-tests
       - functional-tests
@@ -273,10 +273,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      # - uses: actions/download-artifact@v3
-      #   with:
-      #     name: cypress-code-coverage-report
-      #     path: coverage-cypress/
+      - uses: actions/download-artifact@v3
+        with:
+          name: cypress-code-coverage-report
+          path: coverage-cypress/
       - uses: actions/download-artifact@v3
         with:
           name: unit-tests-code-coverage-report
@@ -293,7 +293,7 @@ jobs:
         run: |
           mkdir .nyc_output
           mkdir coverage-reports
-          # cp coverage-cypress/.nyc_output/*.json coverage-reports
+          cp coverage-cypress/.nyc_output/*.json coverage-reports
           cp coverage-unit-tests/.nyc_output/*.json coverage-reports
           cp coverage-functional-tests/.nyc_output/*.json coverage-reports
           cp coverage-integration-tests/.nyc_output/*.json coverage-reports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,17 +261,17 @@ jobs:
   coverage:
     name: Send coverage reports to Codacy
     needs:
-      - cypress-tests
+      # - cypress-tests
       - approval-tests
       - unit-tests
       - functional-tests
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
-        with:
-          name: cypress-code-coverage-report
-          path: coverage-cypress/
+      # - uses: actions/checkout@v4
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: cypress-code-coverage-report
+      #     path: coverage-cypress/
       - uses: actions/download-artifact@v3
         with:
           name: unit-tests-code-coverage-report
@@ -288,7 +288,7 @@ jobs:
         run: |
           mkdir .nyc_output
           mkdir coverage-reports
-          cp coverage-cypress/.nyc_output/*.json coverage-reports
+          # cp coverage-cypress/.nyc_output/*.json coverage-reports
           cp coverage-unit-tests/.nyc_output/*.json coverage-reports
           cp coverage-functional-tests/.nyc_output/*.json coverage-reports
           cp coverage-integration-tests/.nyc_output/*.json coverage-reports


### PR DESCRIPTION
## What does this PR do / solve?

`cp: cannot stat 'coverage-cypress/.nyc_output/*.json': No such file or directory` error from https://github.com/openwhyd/openwhyd/actions/runs/11870400622/job/33082183227?pr=776#step:7:15
