### PR TITLE
fix(bookmarklet): safer way to trim whitespace from titles 

### DIFF
--- a/misc/BrowserExt/Chrome/bookmarklet.js
+++ b/misc/BrowserExt/Chrome/bookmarklet.js
@@ -20,7 +20,7 @@
       eidSet[url] = true;
       cb({
         id: url,
-        title: title.replace(/^\s+|\s+$/g, ''),
+        title: title.trim(),
         img: '/images/cover-audiofile.png',
       });
     };

--- a/public/js/bookmarklet.js
+++ b/public/js/bookmarklet.js
@@ -20,7 +20,7 @@
       eidSet[url] = true;
       cb({
         id: url,
-        title: title.replace(/^\s+|\s+$/g, ''),
+        title: title.trim(),
         img: '/images/cover-audiofile.png',
       });
     };

--- a/public/js/bookmarkletUrlDetectors.ts
+++ b/public/js/bookmarkletUrlDetectors.ts
@@ -28,7 +28,7 @@ function makeFileDetector(): UrlDetector {
     eidSet[url] = true;
     cb({
       id: url,
-      title: title.replace(/^\s+|\s+$/g, ''),
+      title: title.trim(),
       img: '/images/cover-audiofile.png',
     });
   };


### PR DESCRIPTION
cf https://sonarcloud.io/project/security_hotspots?id=openwhyd_openwhyd&branch=main&issueStatuses=OPEN,CONFIRMED&sinceLeakPeriod=true

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/9c76b714-e015-4f53-affe-1150069ec09c">
