### PR TITLE
fix: don't allow user renaming in case of validation error

### DIFF
--- a/app/lib/auth0/features.js
+++ b/app/lib/auth0/features.js
@@ -66,12 +66,13 @@ exports.makeAuthFeatures = (env) => {
       });
     },
 
+    /**
+     * @param {string} userId
+     * @param {string} name
+     * @throws {ManagementApiError} e.g. if name is too short
+     */
     async setUserProfileName(userId, name) {
-      await auth0
-        .patchUser(userId, { name })
-        .catch((err) =>
-          console.trace('failed to forward user rename to Auth0:', err),
-        );
+      await auth0.patchUser(userId, { name });
     },
 
     async deleteUser(userId) {

--- a/app/models/user.js
+++ b/app/models/user.js
@@ -737,7 +737,7 @@ exports.setHandle = function (features, uId, username, handler) {
 };
 
 /** @param {{auth?: import('../lib/my-http-wrapper/http/AuthFeatures.js').AuthFeatures}} features */
-exports.renameUser = function (features, uid, name, callback) {
+exports.renameUser = async function (features, uid, name, callback) {
   function whenDone() {
     console.log('renameUser last step: save the actual user record');
     exports.save({ _id: uid, name: name }, callback);
@@ -751,7 +751,12 @@ exports.renameUser = function (features, uid, name, callback) {
   } else if (oldName == name) {
     callback({}); // nothing to do
   } else {
-    features.auth?.setUserProfileName(uid, name);
+    try {
+      await features.auth?.setUserProfileName(uid, name); // validates the name
+    } catch (err) {
+      callback({ error: err.message }); // e.g. "String is too short (0 chars)"
+      return;
+    }
     // update user name in other collections where it's mentionned
     (function next() {
       let col;


### PR DESCRIPTION
## What does this PR do / solve?

When a user tries to change their profile name to an empty string:
- Auth0 rejects
- the error is logged twice
- but the renaming happens in db anyway
- and no user feedback is provided.

Error logs:

```
07:26:09 UTC | openwhyd-2gb
[31m Error -- Tue, 24 Dec 2024 07:26:08 GMT Trace: failed to forward user rename to Auth0: ManagementApiError: Payload validation error: 'String is too short (0 chars), minimum 1' on property name (Name of this user).
07:26:08 UTC | openwhyd-2gb
msg: "Payload validation error: 'String is too short (0 chars), minimum 1' on property name (Name of this user)."
07:26:08 UTC | openwhyd-2gb
body: `{"statusCode":400,"error":"Bad Request","message":"Payload validation error: 'String is too short (0 chars), minimum 1' on property name (Name of this user).","errorCode":"invalid_body"}`,
```

## Overview of changes

- let the error from Auth0 bubble up to the caller
- catch it and callback with error instead of proceeding with the rename in db

## How to test this PR?

<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
