### PR TITLE
fix(users): logout after user deletion

### DIFF
--- a/app/controllers/private/register.js
+++ b/app/controllers/private/register.js
@@ -216,18 +216,28 @@ exports.registerInvitedUser = function (request, user, response) {
   else registerUser();
 };
 
+/**
+ * Handler of API route used for user registration / signup.
+ * @param {*} request
+ * @param {*} getParams
+ * @param {*} response
+ * @param {{ auth: import('../../lib/my-http-wrapper/http/AuthFeatures.js').AuthFeatures }} features
+ */
 exports.controller = async function (request, getParams, response, features) {
   request.logToConsole('register.controller', request.method);
   const newUserFromAuth0 = features.auth?.getAuthenticatedUser(request);
   if (newUserFromAuth0) {
+    console.log(`New user from Auth0, id: ${newUserFromAuth0.id}`);
     // finalize user signup from Auth0, by persisting them into our database
     const storedUser = await new Promise((resolve) =>
       userModel.save(newUserFromAuth0, resolve),
     );
     if (storedUser) {
+      console.log(`New user from Auth0, stored with _id: ${storedUser._id}`);
       notifEmails.sendRegWelcomeAsync(storedUser);
       response.renderHTML(htmlRedirect('/')); // in reality, this ends up redirecting to the consent request page
     } else {
+      console.error(`New user from Auth0, failed to be stored in db`);
       renderError(
         request,
         storedUser,

--- a/public/js/settings.js
+++ b/public/js/settings.js
@@ -64,6 +64,9 @@ $(function () {
       console.log('response', response);
       globals.avgrundClose();
       globals.showMessage(response);
+      setTimeout(() => {
+        window.location.href = '/logout';
+      }, 2000);
     });
   }
 


### PR DESCRIPTION
## What does this PR do / solve?

When a user deletes their account, their session remains active whereas they were removes from the `usernames` cache => notification poll pollutes logs with `logged user <UID> not found in user cache` errors.

## Overview of changes

After deleting a user account, also logout.
