### PR TITLE
fix(auth): always check if logged in user needs to register/signup

### DIFF
--- a/app/controllers/private/register.js
+++ b/app/controllers/private/register.js
@@ -242,8 +242,9 @@ exports.controller = async function (request, getParams, response, features) {
       `New user from Auth0, id: ${newUserFromAuth0.id}, handle: ${newUserFromAuth0.name}`,
     );
     // finalize user signup from Auth0, by persisting them into our database
-    const storedUser = await new Promise((resolve) =>
-      userModel.save(newUserFromAuth0, resolve),
+    const storedUser = await new Promise(
+      (resolve) => userModel.save(newUserFromAuth0, resolve),
+      // TODO: save newUserFromAuth0.name as storedUser.handle?
     );
     if (storedUser) {
       console.log(

--- a/app/lib/auth0/index.js
+++ b/app/lib/auth0/index.js
@@ -36,6 +36,7 @@ exports.getAuthenticatedUserId = (request) => {
  */
 exports.getAuthenticatedUser = (request) => {
   if (!request.oidc?.isAuthenticated()) return null;
+  /** @type {OidcUser} */
   const { sub, name, email, picture } = request.oidc.user;
   if (typeof sub !== 'string') throw new Error('invalid sub');
   if (typeof name !== 'string') throw new Error('invalid name');
@@ -78,6 +79,12 @@ exports.Auth0Wrapper = class Auth0Wrapper {
       secret: this.env.AUTH0_SECRET,
       clientID: this.env.AUTH0_CLIENT_ID,
       issuerBaseURL: this.env.AUTH0_ISSUER_BASE_URL,
+      // cf https://auth0.github.io/express-openid-connect/interfaces/ConfigParams.html#getLoginState
+      getLoginState() {
+        return {
+          returnTo: '/register',
+        };
+      },
       session: {
         cookie: {
           domain: new URL(urlPrefix).hostname,


### PR DESCRIPTION
Follow up of https://github.com/openwhyd/openwhyd/commit/67e39b56ced420963d886952749a661139f22727.

## What does this PR do / solve?

As explained in [\`oidc.isAuthenticated()\` returns true even though the user does not exist in Auth0 - Auth0 Community](https://community.auth0.com/t/oidc-isauthenticated-returns-true-even-though-the-user-does-not-exist-in-auth0/169242/1): logs show that some users are logged in on openwhyd.org but don't have a user account on our db. This causes `logged user <UID> not found in user cache` warnings, and prevents the user to add tracks to their profile.

How to reproduce, as a visitor on openwhyd.org:
- click on login
- on the auth0 form, click on signup
- enter credentials for new user account
=> you are redirected to openwhyd.org, the login button is still visible (as if you were not logged in), and no user account was created on openwhyd's db

Why does this happen?

User account creation must go through the `/register` endpoint, which happens only when user clicked on OUR `/signup` endpoint, because that endpoint specifies `returnTo: `/register'`, but this doesn't happen when the user clicked on auth0's "sign up" link. (from auth0 "login" page)

## Overview of changes

Always go through the `/register` endpoint whenever receiving logging state from Auth0.

## How to test this PR?

Tested locally with a development Auth0 account.

## Learnings

- The https://github.com/auth0/express-openid-connect plugin for Express automatically exposes a `/callback` route that is called whenever a user logs in or signs up using Auth0. By default, that's the only URL that Auth0 will navigate to, cf Auth0 tenant configuration, as [suggested in the library's README](https://github.com/auth0/express-openid-connect?tab=readme-ov-file#configure-auth0):

<img width="591" alt="image" src="https://github.com/user-attachments/assets/7512df9a-f60c-4378-9260-1046e23a6ed1" />

- Another way to go would be to setup different callback endpoints, depending on user intent (e.g. login vs signup), cf [the `routes` option](https://auth0.github.io/express-openid-connect/interfaces/ConfigParams.html#routes).