### PR TITLE
fix(api): `InvalidTokenError: Unexpected "aud" value`

### DIFF
--- a/app/lib/my-http-wrapper/http/Application.js
+++ b/app/lib/my-http-wrapper/http/Application.js
@@ -148,11 +148,14 @@ exports.Application = class Application {
     // prototype: v2 API with Auth0
     if (this._features.auth) {
       const { auth } = require('express-oauth2-jwt-bearer'); // to check Authorization Bearer tokens
+
       const useAuth = auth({
         issuerBaseURL: process.env.AUTH0_ISSUER_BASE_URL, // identifier of the Auth0 account
-        audience: `${process.env.URL_PREFIX}/api/v2/`, // identifier of Openwhyd API v2, as set on Auth0
+        audience: `${process.env.WHYD_URL_PREFIX}/api/v2/`, // identifier of Openwhyd API v2, as set on Auth0
         tokenSigningAlg: 'RS256', // as provided by Auth0's quickstart, after creating the API
       });
+      // TODO: on API routes, report errors (e.g. InvalidTokenError) in JSON format: { error: string }
+
       app.post('/api/v2/postTrack', useAuth, async (request, response) => {
         console.log(`/api/v2/postTrack`);
 


### PR DESCRIPTION
follow up of PR #806.

## What does this PR do / solve?

```
$ node app/test-api-v2.js

response: <!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>InvalidTokenError: Unexpected &#39;aud&#39; value<br> &nbsp; &nbsp;at /home/adrien/openwhyd/node_modules/express-oauth2-jwt-bearer/dist/index.js:300:19<br> &nbsp; &nbsp;at async /home/adrien/openwhyd/node_modules/express-oauth2-jwt-bearer/dist/index.js:403:24</pre>
</body>
</html>
```
## Overview of changes

- update audience by using the right env var
- add TODO regarding format/rendering of auth errors, in response to API requests
