### PR TITLE
fix(api): make rate limiter work with HTTP proxy (cloudflare and/or nginx)

### DIFF
--- a/app/lib/my-http-wrapper/http/Application.js
+++ b/app/lib/my-http-wrapper/http/Application.js
@@ -137,6 +137,10 @@ exports.Application = class Application {
 
     // app.set('view engine', 'hogan'); // TODO: use hogan.js to render "mustache" templates when res.render() is called
     app.use(noCache); // called on all requests
+    app.set('trust proxy', 1); // number of proxies between user and server, needed by express-rate-limit
+    app.get('/ip', (request, response) => {
+      response.send(request.ip);
+    });
     app.use(express.static(this._publicDir));
     app.use(makeBodyParser(this._uploadSettings)); // parse uploads and arrays from query params
     this._sessionMiddleware && app.use(this._sessionMiddleware);


### PR DESCRIPTION
## What does this PR do / solve?

Error spotted in production logs, after depoying https://github.com/openwhyd/openwhyd/pull/808 and posting a track to openwhyd.org/adrien from telegram bot:

```
0|openwhyd | ❌ Error -- Wed, 26 Mar 2025 13:14:39 GMT ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy' setting is false (default). This could indicate a misconfiguration which would prevent express-rate-limit from accurately identifying users. See https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/ for more information.
0|openwhyd |     at Object.xForwardedForHeader (/home/adrien/openwhyd/node_modules/express-rate-limit/dist/index.cjs:187:13)
0|openwhyd |     at wrappedValidations.<computed> [as xForwardedForHeader] (/home/adrien/openwhyd/node_modules/express-rate-limit/dist/index.cjs:398:22)
0|openwhyd |     at Object.keyGenerator (/home/adrien/openwhyd/node_modules/express-rate-limit/dist/index.cjs:671:20)
0|openwhyd |     at /home/adrien/openwhyd/node_modules/express-rate-limit/dist/index.cjs:724:32
0|openwhyd |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
0|openwhyd |     at async /home/adrien/openwhyd/node_modules/express-rate-limit/dist/index.cjs:704:5 {
0|openwhyd |   code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR',
0|openwhyd |   help: 'https://express-rate-limit.github.io/ERR_ERL_UNEXPECTED_X_FORWARDED_FOR/'
0|openwhyd | }
```

... and the HTTP request from client got no response from our API.

cf https://github.com/openwhyd/openwhyd/pull/808#issuecomment-2754369261

## Overview of changes

Apply recommendations from https://express-rate-limit.mintlify.app/reference/error-codes#err-erl-unexpected-x-forwarded-for --> https://express-rate-limit.mintlify.app/guides/troubleshooting-proxy-issues.

=> Declare the existence of a proxy, to the Express app.

## How to test this PR?

<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
