### PR TITLE
fix(notif): uncaught error when unloving a post

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,9 +407,6 @@ jobs:
     name: Docker tests
     timeout-minutes: 5
     runs-on: ubuntu-20.04
-    services:
-      docker:
-        options: --memory=4g
     steps:
       - uses: actions/checkout@v4
       - name: Build and start services
@@ -424,10 +421,9 @@ jobs:
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test' # needed by mongodb integration tests (user.repository.tests.js)
       - name: Run API tests
-        run: docker compose exec -T --env MONGODB_URL --env NODE_OPTIONS web npm run test:api:raw
+        run: docker compose exec -T --env MONGODB_URL web npm run test:api:raw
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test'
-          NODE_OPTIONS: '--max-old-space-size=4096'
       - name: Logs from docker compose
         if: ${{ always() }} # this step is useful to troubleshoot the execution of openwhyd when tests fail
         run: docker compose logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -407,8 +407,17 @@ jobs:
     name: Docker tests
     timeout-minutes: 5
     runs-on: ubuntu-20.04
+    services:
+      docker:
+        options: --memory=4g
     steps:
       - uses: actions/checkout@v4
+      - name: Monitor Memory Usage
+        run: |
+          while true; do
+            free -m
+            sleep 5
+          done &
       - name: Build and start services
         run: docker compose up --build --detach
         # env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,12 +412,6 @@ jobs:
         options: --memory=4g
     steps:
       - uses: actions/checkout@v4
-      - name: Monitor Memory Usage
-        run: |
-          while true; do
-            free -m
-            sleep 5
-          done &
       - name: Build and start services
         run: docker compose up --build --detach
         # env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,9 +421,10 @@ jobs:
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test' # needed by mongodb integration tests (user.repository.tests.js)
       - name: Run API tests
-        run: docker compose exec -T --env MONGODB_URL web npm run test:api:raw
+        run: docker compose exec -T --env MONGODB_URL --env NODE_OPTIONS web npm run test:api:raw
         env:
           MONGODB_URL: 'mongodb://mongo:27017/openwhyd_test'
+          NODE_OPTIONS: '--max-old-space-size=4096'
       - name: Logs from docker compose
         if: ${{ always() }} # this step is useful to troubleshoot the execution of openwhyd when tests fail
         run: docker compose logs

--- a/app/models/notif.js
+++ b/app/models/notif.js
@@ -233,6 +233,12 @@ exports.html = function (uId, html, href, img) {
 
 // specific notification methods
 
+/** @typedef {{_id: import('mongodb').ObjectId | string, eId?: string, name?: string, uId?: string}} LovablePost */
+
+/**
+ * @param {import('mongodb').ObjectId | string} loverUid
+ * @param {LovablePost} post
+ */
 exports.love = function (loverUid, post, callback) {
   const user = mongodb.usernames['' + loverUid];
   const author = mongodb.usernames['' + post.uId];
@@ -262,7 +268,12 @@ exports.love = function (loverUid, post, callback) {
   notifEmails.sendLike(user, post, author);
 };
 
-exports.unlove = async function (loverUid, pId) {
+/**
+ * @param {import('mongodb').ObjectId | string} loverUid
+ * @param {LovablePost} post
+ */
+exports.unlove = async function (loverUid, post) {
+  const pId = post._id;
   const criteria = { _id: pId + '/loves' };
   const col = db['notif'];
   await col.updateOne(criteria, { $inc: { n: -1 }, $pull: { lov: loverUid } });

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -606,5 +606,18 @@ describe(`post api`, function () {
       assert.equal(activities[0]?.like?.id, otherUser.id);
       assert.equal(activities[0]?.like?.pId, postId);
     });
+
+    it('should decrease the number of loves of a post that was previously loved', async () => {
+      // Given a post with 1 loves
+      const postId = '000000000000000000000009';
+      await insertPost(postId, { ...postFromOtherUser, lov: [loggedUser.id] });
+
+      // When requesting to decrease the love counter for that post
+      await callPostApi({ action: 'toggleLovePost', pId: postId });
+
+      // Then the user is not included anymore in the list of loves
+      const [postAfter] = await openwhyd.dumpCollection('post');
+      assert.deepEqual(postAfter.lov, []);
+    });
   });
 });

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -607,17 +607,17 @@ describe(`post api`, function () {
       assert.equal(activities[0]?.like?.pId, postId);
     });
 
-    it('should decrease the number of loves of a post that was previously loved', async () => {
-      // Given a post with 1 loves
-      const postId = '000000000000000000000009';
-      await insertPost(postId, { ...postFromOtherUser, lov: [loggedUser.id] });
+    // it('should decrease the number of loves of a post that was previously loved', async () => {
+    //   // Given a post with 1 loves
+    //   const postId = '000000000000000000000009';
+    //   await insertPost(postId, { ...postFromOtherUser, lov: [loggedUser.id] });
 
-      // When requesting to decrease the love counter for that post
-      await callPostApi({ action: 'toggleLovePost', pId: postId });
+    //   // When requesting to decrease the love counter for that post
+    //   await callPostApi({ action: 'toggleLovePost', pId: postId });
 
-      // Then the user is not included anymore in the list of loves
-      const [postAfter] = await openwhyd.dumpCollection('post');
-      assert.deepEqual(postAfter.lov, []);
-    });
+    //   // Then the user is not included anymore in the list of loves
+    //   const [postAfter] = await openwhyd.dumpCollection('post');
+    //   assert.deepEqual(postAfter.lov, []);
+    // });
   });
 });

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -607,7 +607,7 @@ describe(`post api`, function () {
       assert.equal(activities[0]?.like?.pId, postId);
     });
 
-    it('should decrease the number of loves of a post that was previously loved', async () => {
+    (process.env.CI ? it.skip : it)('should decrease the number of loves of a post that was previously loved', async () => {
       // Given a post with 1 loves
       const postId = '000000000000000000000009';
       await insertPost(postId, { ...postFromOtherUser, lov: [loggedUser.id] });

--- a/test/api/post.api.tests.js
+++ b/test/api/post.api.tests.js
@@ -607,7 +607,7 @@ describe(`post api`, function () {
       assert.equal(activities[0]?.like?.pId, postId);
     });
 
-    (process.env.CI ? it.skip : it)('should decrease the number of loves of a post that was previously loved', async () => {
+    it('should decrease the number of loves of a post that was previously loved', async () => {
       // Given a post with 1 loves
       const postId = '000000000000000000000009';
       await insertPost(postId, { ...postFromOtherUser, lov: [loggedUser.id] });


### PR DESCRIPTION
## What does this PR do / solve?

Error spotted several times in production logs:

```
[31m❌ Error -- Fri, 04 Apr 2025 21:23:32 GMT TypeError: Cannot read properties of null (reading 'lov')
 at exports.unlove (/home/adrien/openwhyd/app/models/notif.js:270:12)
 at process.processTicksAndRejections (node:internal/process/task_queues:95:5)[39m
```

## Overview of changes

This happens because the `unlove` function from `notif.js` is passed a whole `post` object (like for the `love` function), whereas that function expects a `pId` value instead.

=> Fix this error by harmonizing parameters for the `love` and `unlove` function: both should take a `post` object.

## How to test this PR?

<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
