### PR TITLE
fix(ci): use more recent ubuntu version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
   dependencies:
     name: Check dependencies (with audit)
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -28,7 +28,7 @@ jobs:
   decommission:
     name: Decommission of user cache
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -44,7 +44,7 @@ jobs:
     name: Code checks
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -67,7 +67,7 @@ jobs:
     name: Approval tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       mongodb:
         image: docker://mongo:3.6
@@ -91,7 +91,7 @@ jobs:
     name: Unit tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -116,7 +116,7 @@ jobs:
     name: Functional tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -141,7 +141,7 @@ jobs:
     name: Integration tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       mongodb:
         image: docker://mongo:3.6@sha256:146c1fd999a660e697aac40bc6da842b005c7868232eb0b7d8996c8f3545b05d
@@ -171,7 +171,7 @@ jobs:
     name: 3rd-party tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -188,7 +188,7 @@ jobs:
     name: Cypress E2E tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       mongodb:
         image: docker://mongo:3.6
@@ -266,7 +266,7 @@ jobs:
     name: Auth tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     timeout-minutes: 8
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     services:
       mongodb:
         image: docker://mongo:3.6
@@ -328,7 +328,7 @@ jobs:
       - unit-tests
       - functional-tests
       - integration-tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4.1.7
@@ -376,7 +376,7 @@ jobs:
       - cypress-tests
       - third-party-tests
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -406,7 +406,7 @@ jobs:
     # To publish the Docker image from here, see https://github.com/openwhyd/openwhyd/pull/308/commits/1eacaa98885789642ba0073c9bb4d822021f0d95#diff-12a86cef0c4707531fdbabac3e38cb2aR36
     name: Docker tests
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Build and start services

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,8 @@ jobs:
           - 27117:27017
     steps:
       - uses: actions/checkout@v4
+      - name: Install GraphicsMagick
+        run: sudo apt-get update && sudo apt-get install -y graphicsmagick
       - uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
@@ -211,6 +213,8 @@ jobs:
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
+      - name: Install GraphicsMagick
+        run: sudo apt-get update && sudo apt-get install -y graphicsmagick
       - uses: actions/setup-node@v3
         with:
           node-version: '${{ steps.nvmrc.outputs.node_version }}'

--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ test-in-docker: ## Run tests in the Openwhyd's docker container
 ci: ## Run automated tests defined in GitHub Actions CI workflow.
 	@echo 'ℹ️  Prerequisite: https://github.com/nektos/act#installation-through-package-managers'
 	@echo '{"head_commit": {"message": "build latest"}}' >github_event.tmp
-	@act --job tests --platform "ubuntu-20.04=lucasalt/act_base:latest" --container-architecture linux/amd64 -s GITHUB_TOKEN=${GITHUB_TOKEN} -e github_event.tmp
+	@act --job tests --platform "ubuntu-24.04=lucasalt/act_base:latest" --container-architecture linux/amd64 -s GITHUB_TOKEN=${GITHUB_TOKEN} -e github_event.tmp
 	# TODO: run other CI jobs too.
 	@rm -f github_event.tmp
 


### PR DESCRIPTION
## What does this PR do / solve?

CI checks don't run:

<img width="874" alt="image" src="https://github.com/user-attachments/assets/bda50382-cf5b-4481-bb8c-de6e1a51d2c9" />

Because of a `This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101` error:

<img width="1066" alt="image" src="https://github.com/user-attachments/assets/c9a772ed-3e2d-45e9-b7be-c4487908699c" />

## Overview of changes

Update ubuntu version used in CI, as suggested in https://github.com/actions/runner-images/issues/11101.

## How to test this PR?

CI checks pass.
