### PR TITLE
fix(api): validate parameters of post api

### DIFF
--- a/app/controllers/api/post.js
+++ b/app/controllers/api/post.js
@@ -49,6 +49,14 @@ function fetchSubscribedUsers(uidList, uid, cb) {
 
 const publicActions = {
   lovers: function (p, callback) {
+    if (!p.pId || !mongodb.isObjectId(p.pId)) {
+      callback?.({ error: 'invalid parameter: pId' });
+      return;
+    }
+    if (!p.uId || !mongodb.isObjectId(p.uId)) {
+      callback?.({ error: 'invalid parameter: uId' });
+      return;
+    }
     postModel.fetchPostById(p.pId, function (post) {
       const lovers = [];
       if (post && post.lov)
@@ -70,6 +78,14 @@ const publicActions = {
   },
 
   reposts: function (p, callback) {
+    if (!p.pId || !mongodb.isObjectId(p.pId)) {
+      callback?.({ error: 'invalid parameter: pId' });
+      return;
+    }
+    if (!p.uId || !mongodb.isObjectId(p.uId)) {
+      callback?.({ error: 'invalid parameter: uId' });
+      return;
+    }
     postModel.fetchPosts(
       { 'repost.pId': p.pId },
       null,
@@ -125,6 +141,15 @@ exports.actions = {
    * @param createPlaylist {import('../../domain/api/Features').CreatePlaylist}
    */
   insert: async function (httpRequestParams, callback, _, { createPlaylist }) {
+    if (!httpRequestParams.pId || !mongodb.isObjectId(httpRequestParams.pId)) {
+      callback?.({ error: 'invalid parameter: pId' });
+      return;
+    }
+    if (!httpRequestParams.uId || !mongodb.isObjectId(httpRequestParams.uId)) {
+      callback?.({ error: 'invalid parameter: uId' });
+      return;
+    }
+
     const postRequest = {
       uId: httpRequestParams.uId,
       uNm: httpRequestParams.uNm,
@@ -199,15 +224,27 @@ exports.actions = {
     actualInsert();
   },
   delete: function (p, callback) {
-    if (p.uId) {
-      postModel.deletePost(p._id, p.uId, function (err, result) {
-        callback(err ? { error: err } : (result || {}).pop ? result.pop() : {});
-      });
-    } else {
-      callback({ error: 'please login first' });
+    if (!p._id || !mongodb.isObjectId(p._id)) {
+      callback?.({ error: 'invalid parameter: _id' });
+      return;
     }
+    if (!p.uId || !mongodb.isObjectId(p.uId)) {
+      callback?.({ error: 'please login first' });
+      return;
+    }
+    postModel.deletePost(p._id, p.uId, function (err, result) {
+      callback(err ? { error: err } : (result || {}).pop ? result.pop() : {});
+    });
   },
   toggleLovePost: function (p, callback) {
+    if (!p.pId || !mongodb.isObjectId(p.pId)) {
+      callback?.({ error: 'invalid parameter: pId' });
+      return;
+    }
+    if (!p.uId || !mongodb.isObjectId(p.uId)) {
+      callback?.({ error: 'invalid parameter: uId' });
+      return;
+    }
     postModel.isPostLovedByUid(p.pId, p.uId, function (loved, post) {
       if (!post) callback({ loved: false, lovers: 0 });
       // to prevent crash when trying to love a repost
@@ -268,6 +305,10 @@ exports.actions = {
   },
   scrobble: function (p, cb) {
     if (!p.uId) return cb && cb({ error: 'not logged in' });
+    if (!p.pId || !mongodb.isObjectId(p.pId)) {
+      cb?.({ error: 'invalid parameter: pId' });
+      return;
+    }
     postModel.fetchPostById(p.pId, function (r) {
       if (!r) return cb && cb({ error: 'missing track' });
       userModel.fetchAndProcessUserById(p.uId).then((user) => {

--- a/app/controllers/api/post.js
+++ b/app/controllers/api/post.js
@@ -141,12 +141,20 @@ exports.actions = {
    * @param createPlaylist {import('../../domain/api/Features').CreatePlaylist}
    */
   insert: async function (httpRequestParams, callback, _, { createPlaylist }) {
-    if (!httpRequestParams.pId || !mongodb.isObjectId(httpRequestParams.pId)) {
-      callback?.({ error: 'invalid parameter: pId' });
-      return;
-    }
     if (!httpRequestParams.uId || !mongodb.isObjectId(httpRequestParams.uId)) {
       callback?.({ error: 'invalid parameter: uId' });
+      return;
+    }
+    if (
+      !mongodb.isObjectId(httpRequestParams._id) &&
+      !mongodb.isObjectId(httpRequestParams.pId) &&
+      !httpRequestParams.eId
+    ) {
+      // either _id, pId or eId must be provided:
+      // - _id, to edit an existing post
+      // - pId, to repost an existing track
+      // - eId, to post a new track
+      callback?.({ error: 'invalid parameter: eId or pId' });
       return;
     }
 

--- a/app/controllers/api/user.js
+++ b/app/controllers/api/user.js
@@ -385,6 +385,9 @@ function handleAuthRequest(loggedUser, reqParams, localRendering, features) {
 
 // old name: setUserFields()
 function handleRequest(loggedUser, reqParams, localRendering, features) {
+  console.log('api.user.handleRequest', {
+    action: reqParams.action ?? '(EDIT)',
+  });
   try {
     if (handlePublicRequest(loggedUser, reqParams, localRendering, features))
       return true;


### PR DESCRIPTION
## What does this PR do / solve?

Error found [on datadog](https://app.datadoghq.com/logs?query=host%3Aopenwhyd-2gb%20service%3Aopenwhyd&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&context_event=AZcbbucOAADOssONU5Z6PQBN&fromUser=true&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=time%2Cdesc&viz=&from_ts=1748511641697&to_ts=1748511996763&live=false):

<img width="1220" alt="image" src="https://github.com/user-attachments/assets/1126fe76-437f-42ce-a694-867414a86727" />

A `GET /api/post?action=lovers&...` request lead to logging a `BSONTypeError: Argument passed in must be a string of 12 bytes or a string of 24 hex characters or an integer (value: undefined)` error, which are now appearing often in logs.

## Overview of changes

Instead of polluting logs, return an error to the caller of the API endpoint.

## How to test this PR?

<!-- Provide steps that the reviewer can follow to quickly test your PR. -->
