### PR TITLE
fix(start-up): print steps of db initialization + use promises

### DIFF
--- a/app/models/mongodb-shell-runner.js
+++ b/app/models/mongodb-shell-runner.js
@@ -3,14 +3,13 @@
 const vm = require('vm');
 const mongodb = require('mongodb');
 
-const PRINT_ACTIVE = false;
 const LOG_PREFIX = '[mongo shell]';
 const TIMEOUT_MS = 2 * 60 * 1000; // two minutes
 
-function buildContext(db, callback) {
+function buildContext(db, options = {}) {
   const context = {
     print: function () {
-      PRINT_ACTIVE &&
+      options.print &&
         console.log.apply(
           console,
           [LOG_PREFIX].concat(Array.prototype.slice.call(arguments)),
@@ -21,19 +20,15 @@ function buildContext(db, callback) {
       return new mongodb.ObjectId('' + v);
     },
   };
-  callback(null, context);
+  return context;
 }
 
 // this method runs the commands of a mongo shell script (e.g. initdb.js)
-exports.runScriptOnDatabase = function (script, db, callback) {
-  buildContext(db, async function (err, contextObj) {
-    if (!err) {
-      await vm.runInNewContext(
-        `Promise.resolve().then(async () => { ${script} });`,
-        vm.createContext(contextObj),
-        { timeout: TIMEOUT_MS, microtaskMode: 'afterEvaluate' },
-      );
-    }
-    callback(err);
-  });
+exports.runScriptOnDatabase = async function (script, db) {
+  const contextObj = buildContext(db, { print: true });
+  await vm.runInNewContext(
+    `Promise.resolve().then(async () => { ${script} });`,
+    vm.createContext(contextObj),
+    { timeout: TIMEOUT_MS, microtaskMode: 'afterEvaluate' },
+  );
 };

--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -173,7 +173,9 @@ exports.initCollections = async function ({ addTestData = false } = {}) {
   }
   for (const initScript of dbInitScripts) {
     console.log('[db] Applying db init script:', initScript, '...');
-    await exports.runShellScript(await fs.promises.readFile(initScript, 'utf8'));
+    await exports.runShellScript(
+      await fs.promises.readFile(initScript, 'utf8'),
+    );
   }
   // all db init scripts were interpreted => continue app init
   await util.promisify(exports.cacheCollections)();

--- a/app/models/mongodb.js
+++ b/app/models/mongodb.js
@@ -173,7 +173,7 @@ exports.initCollections = async function ({ addTestData = false } = {}) {
   }
   for (const initScript of dbInitScripts) {
     console.log('[db] Applying db init script:', initScript, '...');
-    await exports.runShellScript(await fs.promises.readFile(initScript));
+    await exports.runShellScript(await fs.promises.readFile(initScript, 'utf8'));
   }
   // all db init scripts were interpreted => continue app init
   await util.promisify(exports.cacheCollections)();

--- a/config/initdb.js
+++ b/config/initdb.js
@@ -23,7 +23,7 @@ await Promise.all([
   db.createCollection('comment').catch(tolerateError('already exists')),
 ]);
 
-// print('indexing post collection...');
+print('indexing post collection...');
 await db.collection('post').createIndex({ uId: 1 });
 await db
   .collection('post')
@@ -35,11 +35,11 @@ await db.collection('post').createIndex({ lov: 1 }, { sparse: true });
 await db.collection('post').createIndex({ 'repost.pId': 1 }, { sparse: true });
 await db.collection('post').createIndex({ 'repost.uId': 1 }, { sparse: true });
 
-// print('indexing follow collection...');
+print('indexing follow collection...');
 await db.collection('follow').createIndex({ uId: 1 });
 await db.collection('follow').createIndex({ tId: 1 });
 
-// print('indexing user collection...');
+print('indexing user collection...');
 await db.collection('user').createIndex({ email: 1 });
 await db.collection('user').createIndex({ handle: 1 }, { sparse: true });
 await db.collection('user').createIndex({ n: 1 }, { sparse: true });
@@ -47,7 +47,7 @@ await db.collection('user').createIndex({ 'pref.pendEN': 1 }, { sparse: true });
 await db.collection('user').createIndex({ 'pref.nextEN': 1 }, { sparse: true });
 await db.collection('user').createIndex({ 'sp.id': 1 }, { sparse: true }); // spotify id
 
-// print('removing legacy fields on user collection...');
+print('removing legacy fields on user collection...');
 await db
   .collection('user')
   .dropIndex({ fbId: 1 })
@@ -58,7 +58,7 @@ await db
   .catch(tolerateError("can't find index"));
 await db.collection('user').updateMany({}, { $unset: { apTok: 1 } });
 
-// print('indexing activity collection...');
+print('indexing activity collection...');
 await db
   .collection('activity')
   .createIndex({ id: 1 }, { sparse: true }); /*poster.id*/
@@ -67,10 +67,10 @@ await db
   .collection('activity')
   .createIndex({ 'like.pId': 1 }, { sparse: true });
 
-// print('indexing comment collection...');
+print('indexing comment collection...');
 await db.collection('comment').createIndex({ pId: 1 });
 
-// print('indexing notif collection...');
+print('indexing notif collection...');
 await db.collection('notif').createIndex({ uId: 1 });
 
 print('done! :-)');

--- a/test/integration/notif-tests.js
+++ b/test/integration/notif-tests.js
@@ -122,9 +122,10 @@ describe('notifications', function () {
   this.timeout(5000);
 
   // reset database state and seed fixtures (including ADMIN_USER)
-  before(async () => await resetTestDb({ env: process.env, silent: true }));
-
-  before(initDb);
+  before(async () => {
+    await resetTestDb({ env: process.env, silent: true });
+    await initDb();
+  });
 
   it('can clean notifications db', async () => {
     // remove documents with empty uid

--- a/test/reset-test-db.js
+++ b/test/reset-test-db.js
@@ -34,8 +34,7 @@ mongodb.init(dbCreds, async (err, db) => {
     if (DEBUG)
       console.log(`[test-db-init.js] Applying script: ${initScript} ...`);
     const script = await fs.promises.readFile(initScript);
-    // @ts-ignore
-    await util.promisify(mongodb.runShellScript)(script);
+    await mongodb.runShellScript(script);
   }
   // delete uploaded files
   await new ImageStorage()


### PR DESCRIPTION
## What does this PR do / solve?

When restarting openwhyd in production, the db initialization step (which includes migrations) takes 10~20 seconds to run, which is significant.

## Overview of changes

Investigate which part of this initialization takes most time, so we can optimize it.
