### PR TITLE
fix(stream): home feed should not end prematurely + fix Cypress tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,7 @@ jobs:
         containers: [1, 2, 3]
     steps:
       # to avoid browserVersion mismatch, cf https://github.com/cypress-io/github-action/issues/518#issuecomment-1210979047
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
       - run: |
           echo "Chrome version: $(chrome --version)"
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV
@@ -263,7 +263,7 @@ jobs:
           - 27117:27017
     steps:
       # to avoid browserVersion mismatch, cf https://github.com/cypress-io/github-action/issues/518#issuecomment-1210979047
-      - uses: browser-actions/setup-chrome@latest
+      - uses: browser-actions/setup-chrome@v1
       - run: |
           echo "Chrome version: $(chrome --version)"
           echo "BROWSER_PATH=$(which chrome)" >> $GITHUB_ENV

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -133,7 +133,7 @@ exports.fetchByAuthors = async function (uidList, options, cb) {
   });
 
   // we may exclude some documents from the cursor => don't pass limit to find()
-  const nbRequestedPosts = (parseInt(options.limit) || NB_POSTS) + 1;
+  const nbRequestedPosts = (parseInt(options.limit, 10) || NB_POSTS) + 1;
 
   const cursor = mongodb.collections['post'].find(query).sort(DEFAULT_SORT);
   try {

--- a/app/models/post.js
+++ b/app/models/post.js
@@ -66,6 +66,7 @@ function processAdvQuery(query, params, options) {
   if (!params.sort) params.sort = [/*['rTm','desc'],*/ ['_id', 'desc']]; // by default
 }
 
+// called by `/all` route, among others
 exports.fetchPosts = async function (query, params, options, handler) {
   params = params || {};
   processAdvQuery(query, params, options);
@@ -117,6 +118,7 @@ exports.fetchByAuthorsOld = function (uidList, options, handler) {
   );
 };
 
+// called by /stream endpoint, among others
 exports.fetchByAuthors = async function (uidList, options, cb) {
   const loggedUser = uidList[uidList.length - 1];
   console.time(`fetchByAuthors>arrayToSet_${loggedUser}`);

--- a/scripts/import-from-prod.js
+++ b/scripts/import-from-prod.js
@@ -1,8 +1,9 @@
 // Import tracks from a user profile on openwhyd.org, to the local test db.
 //
 // Usage:
-//   $ make docker-seed                         # clears the database and creates the admin user
-//   $ node scripts/import-from-prod.js adrien  # imports 21 posts from https://openwhyd.org/adrien
+//   $ make docker-seed                          # clears the database and creates the admin user
+//   $ node scripts/import-from-prod.js adrien 5 # imports 5 posts from https://openwhyd.org/adrien
+//   $ node scripts/import-from-prod.js u/5911f8e098267ba4b34b8424 # ... or specify a user by id
 
 const request = require('request');
 const mongodb = require('mongodb');
@@ -18,6 +19,7 @@ const password = {
   plain: 'admin',
   md5: '21232f297a57a5a743894a0e4a801fc3',
 };
+const nbPosts = process.argv[3] ? parseInt(process.argv[3]) : 21;
 const importSubscribers = false;
 
 const connectToDb = ({ url, dbName }) => {
@@ -36,7 +38,7 @@ const fetchUserProfile = ({ username }) =>
 
 const fetchUserPosts = ({ username }) =>
   new Promise((resolve, reject) => {
-    const url = `https://openwhyd.org/${username}?format=json`;
+    const url = `https://openwhyd.org/${username}?format=json&limit=${nbPosts}`;
     console.log(`fetching tracks from ${url} ...`);
     request(url, (err, _, body) =>
       err


### PR DESCRIPTION
<!-- First: give a concise but precise title to the PR -->
<!-- (preferably compliant with conventionalcommits.org) -->
<!-- (read CONTRIBUTING.md for more information ) -->

Closes #<!-- enter issue number here -->.

## What does this PR do / solve?

The stream of posts listed in the user's home feed ends prematurely when it contains at least one track that was reposted from a followed user.

https://github.com/user-attachments/assets/4696e183-74cf-4c6c-b3ee-1ccbd5d73bc4

This is probably a regression introduced when decommissioning the `forEach2` function, in https://github.com/openwhyd/openwhyd/pull/833.

## Overview of changes

- Fix main issue by giving control of the `limit` to our cursor-based iteration logic, instead of passing it to `find()`.
- Fix Cypress tests on CI by forcing the use of [browser-actions/setup-chrome@v1](https://github.com/browser-actions/setup-chrome/releases/tag/v1.7.3)