### PR TITLE
fix(api): allow jsonp callback on public user info endpoints

### DIFF
--- a/app/controllers/publicUserInfo.js
+++ b/app/controllers/publicUserInfo.js
@@ -21,10 +21,12 @@ exports.controller = async function (request, reqParams, response) {
     if (reqParams.callback) {
       // the callback parameter is used for JSONP responses, for use from client-side JS
       const safeCallback = reqParams.callback.replace(/[^a-z0-9_]/gi, '');
+      if (!safeCallback) {
+        return response.badRequest({ error: 'Invalid callback parameter' });
+      }
       response
         .set({ 'content-type': 'application/javascript' })
         .send(safeCallback + '(' + JSON.stringify(responseBody) + ')');
-    } else {
       // regular JSON response
       response.renderJSON(responseBody);
     }


### PR DESCRIPTION
## What does this PR do / solve?

Openwhyd mobile web client still can't fetch user info, because it requires a JSONP callback.

## Overview of changes

Similarly to other public user export API, support JSONP calls to `/info` endpoints.

=> When passed a `callback` parameter, the API endpoint returns a function call to that callback, with the API response body as a parameter of that function.

## How to test this PR?

Tested locally:

<img width="704" height="101" alt="image" src="https://github.com/user-attachments/assets/0a661c55-ea89-4e04-8051-fc326744c573" />
